### PR TITLE
[Feature] Phase 3b — WaddlePerf client module (schedules/config/version)

### DIFF
--- a/core/db/models.py
+++ b/core/db/models.py
@@ -575,6 +575,39 @@ class ServerKey(Base):
         return f"<ServerKey(id={self.id}, tenant={self.tenant}, key_id={self.key_id})>"
 
 
+class TestSchedule(Base):
+    """Test schedules for WaddlePerf client testing."""
+
+    __tablename__ = "test_schedules"
+
+    id: Column[str] = Column(
+        UUID(as_uuid=False),
+        primary_key=True,
+        default=lambda: str(uuid4()),
+        nullable=False,
+    )
+    tenant: Column[str] = Column(String(255), nullable=False, index=True)
+    org_unit_id: Column[str | None] = Column(UUID(as_uuid=False), nullable=True, index=True)
+    test_type: Column[str] = Column(String(50), nullable=False)
+    target: Column[str] = Column(String(255), nullable=False)
+    interval_seconds: Column[int] = Column(Integer, nullable=False)
+    enabled: Column[bool] = Column(Boolean, default=True, nullable=False)
+    created_at: Column[datetime] = Column(
+        DateTime, server_default=func.now(), nullable=False
+    )
+    updated_at: Column[datetime] = Column(
+        DateTime, server_default=func.now(), onupdate=func.now(), nullable=False
+    )
+
+    __table_args__ = (
+        UniqueConstraint("tenant", "org_unit_id", "test_type", "target", name="uq_test_schedules_tenant_ou_type_target"),
+    )
+
+    def __repr__(self) -> str:
+        """Return string representation."""
+        return f"<TestSchedule(id={self.id}, tenant={self.tenant}, test_type={self.test_type})>"
+
+
 __all__ = [
     "User",
     "RefreshToken",
@@ -594,4 +627,5 @@ __all__ = [
     "PerfTestResult",
     "ClientConfig",
     "ServerKey",
+    "TestSchedule",
 ]

--- a/core/migrations/versions/0013_wpc_test_schedules.py
+++ b/core/migrations/versions/0013_wpc_test_schedules.py
@@ -1,0 +1,53 @@
+"""Create test schedules table for WaddlePerf client.
+
+Revision ID: 0013
+Revises: 0012
+Create Date: 2026-07-09 16:00:00.000000
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers
+revision = "0013"
+down_revision = "0012"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    """Create test_schedules table."""
+    op.create_table(
+        "test_schedules",
+        sa.Column("id", sa.String(36), nullable=False),
+        sa.Column("tenant", sa.String(255), nullable=False, index=True),
+        sa.Column("org_unit_id", sa.String(36), nullable=True, index=True),
+        sa.Column("test_type", sa.String(50), nullable=False),
+        sa.Column("target", sa.String(255), nullable=False),
+        sa.Column("interval_seconds", sa.Integer(), nullable=False),
+        sa.Column("enabled", sa.Boolean(), nullable=False, server_default="1"),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+        sa.Column("updated_at", sa.DateTime(), nullable=False),
+        sa.PrimaryKeyConstraint("id", name="pk_test_schedules"),
+        sa.UniqueConstraint(
+            "tenant",
+            "org_unit_id",
+            "test_type",
+            "target",
+            name="uq_test_schedules_tenant_ou_type_target",
+        ),
+    )
+    # Index for common queries: tenant + org_unit_id
+    op.create_index(
+        "ix_test_schedules_tenant_ou",
+        "test_schedules",
+        ["tenant", "org_unit_id"],
+        unique=False,
+    )
+
+
+def downgrade() -> None:
+    """Drop test_schedules table."""
+    op.drop_index("ix_test_schedules_tenant_ou", "test_schedules")
+    op.drop_table("test_schedules")

--- a/core/modules/__init__.py
+++ b/core/modules/__init__.py
@@ -1,3 +1,3 @@
 """Modules package for Tobogganing Core."""
 
-__all__ = ["ping", "sase", "waddleperf_cluster"]
+__all__ = ["ping", "sase", "waddleperf_cluster", "waddleperf_client"]

--- a/core/modules/waddleperf_client/__init__.py
+++ b/core/modules/waddleperf_client/__init__.py
@@ -1,10 +1,7 @@
-"""WaddlePerf client module - test schedule/config distribution + version check.
-
-Scaffold: the full ModuleContract is wired in Phase 3b Group B2. Until then
-this returns an empty contract so the package imports cleanly.
-"""
+"""WaddlePerf client module - test schedule/config distribution + version check."""
 from __future__ import annotations
 
+from core.modules.waddleperf_client.api import blueprints
 from core.registry import Entitlement, ModuleContract, NavEntry
 
 
@@ -12,14 +9,27 @@ def module() -> ModuleContract:
     """Return the module contract for the waddleperf_client module.
 
     Returns:
-        ModuleContract with empty lists during scaffold phase.
+        ModuleContract with WaddlePerf client blueprints, feature flags,
+        and entitlements.
     """
     return ModuleContract(
         name="waddleperf_client",
-        blueprints=[],
-        nav=[],
-        flags=[],
-        entitlements=[],
-        migrations=[],
+        blueprints=list(blueprints),
+        nav=[
+            NavEntry("Schedules", "/api/v1/waddleperf_client/schedules", "calendar"),
+            NavEntry("Config", "/api/v1/waddleperf_client/config", "settings"),
+            NavEntry("Version", "/api/v1/waddleperf_client/version", "info"),
+        ],
+        flags=[
+            "tobogganing.waddleperf_client.schedules",
+            "tobogganing.waddleperf_client.config",
+            "tobogganing.waddleperf_client.version",
+        ],
+        entitlements=[
+            Entitlement("waddleperf_client.schedules", "community"),
+            Entitlement("waddleperf_client.config", "community"),
+            Entitlement("waddleperf_client.version", "community"),
+        ],
+        migrations=["0013"],
         health=None,
     )

--- a/core/modules/waddleperf_client/__init__.py
+++ b/core/modules/waddleperf_client/__init__.py
@@ -1,0 +1,25 @@
+"""WaddlePerf client module - test schedule/config distribution + version check.
+
+Scaffold: the full ModuleContract is wired in Phase 3b Group B2. Until then
+this returns an empty contract so the package imports cleanly.
+"""
+from __future__ import annotations
+
+from core.registry import Entitlement, ModuleContract, NavEntry
+
+
+def module() -> ModuleContract:
+    """Return the module contract for the waddleperf_client module.
+
+    Returns:
+        ModuleContract with empty lists during scaffold phase.
+    """
+    return ModuleContract(
+        name="waddleperf_client",
+        blueprints=[],
+        nav=[],
+        flags=[],
+        entitlements=[],
+        migrations=[],
+        health=None,
+    )

--- a/core/modules/waddleperf_client/api/__init__.py
+++ b/core/modules/waddleperf_client/api/__init__.py
@@ -1,0 +1,1 @@
+"""WaddlePerf client API blueprints (populated in Phase 3b Group B2)."""

--- a/core/modules/waddleperf_client/api/__init__.py
+++ b/core/modules/waddleperf_client/api/__init__.py
@@ -1,1 +1,14 @@
-"""WaddlePerf client API blueprints (populated in Phase 3b Group B2)."""
+"""WaddlePerf client API blueprints."""
+from __future__ import annotations
+
+from core.modules.waddleperf_client.api.schedules import blueprint as schedules_blueprint
+from core.modules.waddleperf_client.api.client_config import blueprint as client_config_blueprint
+from core.modules.waddleperf_client.api.version import blueprint as version_blueprint
+
+blueprints = [
+    schedules_blueprint,
+    client_config_blueprint,
+    version_blueprint,
+]
+
+__all__ = ["blueprints"]

--- a/core/modules/waddleperf_client/api/client_config.py
+++ b/core/modules/waddleperf_client/api/client_config.py
@@ -1,0 +1,137 @@
+"""Client configuration REST API blueprint for WaddlePerf client.
+
+Device-facing endpoint that provides resolved schedules and client config
+based on device API key authentication.
+"""
+from __future__ import annotations
+
+import asyncio
+import structlog
+from datetime import datetime, timezone
+from typing import Any
+
+from quart import Blueprint, current_app, jsonify, request
+
+from core.db import get_db
+from core.entitlements.gate import require_feature
+from core.flags import feature_enabled
+from core.modules.waddleperf_cluster.services.device_auth import authenticate_device_global
+from core.modules.waddleperf_client.services.schedule_manager import ScheduleManager
+
+logger = structlog.get_logger()
+
+blueprint = Blueprint("wpcl_config", __name__, url_prefix="/config")
+
+
+def _extract_bearer_token() -> str | None:
+    """Extract API key from Authorization header.
+
+    Returns:
+        Token string if present, None otherwise.
+    """
+    auth_header = request.headers.get("Authorization", "")
+    if not auth_header.startswith("Bearer "):
+        return None
+    return auth_header[7:]
+
+
+@blueprint.route("", methods=["GET"])
+async def get_client_config() -> tuple[dict[str, Any], int]:
+    """Get client configuration and resolved schedules for a device.
+
+    This is a device-facing endpoint. Authentication is via Bearer token
+    containing an API key (not a JWT). The device's tenant is derived from
+    the device record, not from the request.
+
+    Returns:
+        JSON response with resolved schedules and client config
+    """
+    try:
+        # Extract and validate device API key
+        api_key = _extract_bearer_token()
+        if not api_key:
+            logger.warning("client_config_missing_api_key")
+            return {"error": "Missing or invalid Authorization header"}, 401
+
+        # Authenticate device globally (no tenant trust)
+        db = get_db()
+        auth_result = await authenticate_device_global(db, api_key)
+
+        if auth_result is None:
+            logger.warning("client_config_auth_failed", key_prefix=api_key[:8] if len(api_key) > 8 else "")
+            return {"error": "Invalid device credentials"}, 401
+
+        device, tenant_id = auth_result
+
+        # Check if the feature flag is enabled for this tenant
+        is_enabled = feature_enabled("waddleperf_client", "config", distinct_id=tenant_id)
+
+        if not is_enabled:
+            logger.warning(
+                "client_config_feature_disabled",
+                device_id=device.id,
+                tenant=tenant_id,
+            )
+            return (
+                {
+                    "error": "Feature not available",
+                    "message": "waddleperf_client.config is not enabled",
+                },
+                402,
+            )
+
+        # Resolve schedules for this device
+        mgr = ScheduleManager(db, tenant_id)
+        await mgr.initialize()
+        resolved_schedules = await mgr.resolve_for_device(device)
+
+        # Fetch client configs for this device's org unit
+        client_configs = []
+        if device.org_unit_id:
+            # Query client configs for the org unit
+            try:
+                configs = await asyncio.to_thread(
+                    db.client_configs.select_list,
+                    tenant=tenant_id,
+                    org_unit_id=device.org_unit_id,
+                )
+                client_configs = [c.config or {} for c in configs] if configs else []
+            except Exception as e:
+                logger.error("client_config_fetch_failed", error=str(e))
+                client_configs = []
+
+        schedule_list = [
+            {
+                "id": s.id,
+                "test_type": s.test_type,
+                "target": s.target,
+                "interval_seconds": s.interval_seconds,
+                "enabled": s.enabled,
+                "created_at": s.created_at.isoformat(),
+                "updated_at": s.updated_at.isoformat(),
+            }
+            for s in resolved_schedules
+        ]
+
+        logger.info(
+            "client_config_retrieved",
+            device_id=device.id,
+            tenant=tenant_id,
+            schedule_count=len(schedule_list),
+        )
+
+        return (
+            {
+                "schedules": schedule_list,
+                "config": client_configs[0] if client_configs else {},
+                "meta": {
+                    "version": 1,
+                    "timestamp": datetime.now(timezone.utc).isoformat(),
+                },
+            },
+            200,
+        )
+
+    except Exception as e:
+        logger.error("client_config_error", error=str(e))
+        return {"error": "Internal server error"}, 500

--- a/core/modules/waddleperf_client/api/schedules.py
+++ b/core/modules/waddleperf_client/api/schedules.py
@@ -1,0 +1,334 @@
+"""Schedules REST API blueprint for WaddlePerf client."""
+from __future__ import annotations
+
+import structlog
+from datetime import datetime, timezone
+from typing import Any
+
+from quart import Blueprint, current_app, jsonify, request
+
+from core.auth.middleware import current_claims, require_scope, require_tenant
+from core.db import get_db
+from core.entitlements.gate import require_feature
+from core.modules.waddleperf_client.services.schedule_manager import ScheduleManager
+
+logger = structlog.get_logger()
+
+blueprint = Blueprint("wpcl_schedules", __name__, url_prefix="/schedules")
+
+
+@blueprint.route("", methods=["POST"])
+@require_tenant
+@require_scope("schedules:write")
+@require_feature("waddleperf_client", "schedules")
+async def create_schedule() -> tuple[dict[str, Any], int]:
+    """Create a new test schedule.
+
+    Required scope: schedules:write
+    Required feature: waddleperf_client.schedules
+
+    JSON body:
+        test_type: Test type (required)
+        target: Test target (required)
+        interval_seconds: Test interval in seconds (required)
+        org_unit_id: Organization unit ID (optional)
+        enabled: Whether schedule is enabled (optional, default: true)
+
+    Returns:
+        JSON response with created schedule and meta
+    """
+    try:
+        claims = current_claims()
+        if not claims:
+            return {"error": "Unauthorized"}, 403
+
+        tenant_id = claims["tenant"]
+        data = await request.get_json()
+
+        if not data or "test_type" not in data or "target" not in data or "interval_seconds" not in data:
+            return {"error": "Missing required fields: test_type, target, interval_seconds"}, 400
+
+        db = get_db()
+        mgr = ScheduleManager(db, tenant_id)
+        await mgr.initialize()
+
+        schedule_dto = await mgr.create_schedule(
+            {
+                "test_type": data["test_type"],
+                "target": data["target"],
+                "interval_seconds": data["interval_seconds"],
+                "org_unit_id": data.get("org_unit_id"),
+                "enabled": data.get("enabled", True),
+            }
+        )
+
+        logger.info(
+            "schedule_created",
+            schedule_id=schedule_dto.id,
+            tenant=tenant_id,
+        )
+
+        return (
+            {
+                "id": schedule_dto.id,
+                "tenant": schedule_dto.tenant,
+                "org_unit_id": schedule_dto.org_unit_id,
+                "test_type": schedule_dto.test_type,
+                "target": schedule_dto.target,
+                "interval_seconds": schedule_dto.interval_seconds,
+                "enabled": schedule_dto.enabled,
+                "created_at": schedule_dto.created_at.isoformat(),
+                "updated_at": schedule_dto.updated_at.isoformat(),
+                "meta": {
+                    "version": 1,
+                    "timestamp": datetime.now(timezone.utc).isoformat(),
+                },
+            },
+            201,
+        )
+
+    except Exception as e:
+        logger.error("create_schedule_failed", error=str(e))
+        return {"error": "Internal server error"}, 500
+
+
+@blueprint.route("", methods=["GET"])
+@require_tenant
+@require_scope("schedules:read")
+@require_feature("waddleperf_client", "schedules")
+async def list_schedules() -> tuple[dict[str, Any], int]:
+    """List test schedules for the tenant.
+
+    Query parameters:
+        org_unit_id: Filter by organization unit ID (optional)
+
+    Returns:
+        JSON response with list of schedules and meta
+    """
+    try:
+        claims = current_claims()
+        if not claims:
+            return {"error": "Unauthorized"}, 403
+
+        tenant_id = claims["tenant"]
+        org_unit_id = request.args.get("org_unit_id")
+
+        db = get_db()
+        mgr = ScheduleManager(db, tenant_id)
+        await mgr.initialize()
+
+        schedules = await mgr.list_schedules(org_unit_id=org_unit_id)
+
+        schedule_list = [
+            {
+                "id": s.id,
+                "tenant": s.tenant,
+                "org_unit_id": s.org_unit_id,
+                "test_type": s.test_type,
+                "target": s.target,
+                "interval_seconds": s.interval_seconds,
+                "enabled": s.enabled,
+                "created_at": s.created_at.isoformat(),
+                "updated_at": s.updated_at.isoformat(),
+            }
+            for s in schedules
+        ]
+
+        logger.info(
+            "schedules_listed",
+            count=len(schedule_list),
+            tenant=tenant_id,
+            org_unit_id=org_unit_id,
+        )
+
+        return (
+            {
+                "schedules": schedule_list,
+                "meta": {
+                    "version": 1,
+                    "timestamp": datetime.now(timezone.utc).isoformat(),
+                },
+            },
+            200,
+        )
+
+    except Exception as e:
+        logger.error("list_schedules_failed", error=str(e))
+        return {"error": "Internal server error"}, 500
+
+
+@blueprint.route("/<schedule_id>", methods=["GET"])
+@require_tenant
+@require_scope("schedules:read")
+@require_feature("waddleperf_client", "schedules")
+async def get_schedule(schedule_id: str) -> tuple[dict[str, Any], int]:
+    """Get a test schedule by ID.
+
+    Args:
+        schedule_id: Schedule identifier
+
+    Returns:
+        JSON response with schedule details
+    """
+    try:
+        claims = current_claims()
+        if not claims:
+            return {"error": "Unauthorized"}, 403
+
+        tenant_id = claims["tenant"]
+        db = get_db()
+        mgr = ScheduleManager(db, tenant_id)
+        await mgr.initialize()
+
+        schedule_dto = await mgr.get_schedule(schedule_id)
+
+        if not schedule_dto:
+            return {"error": "Schedule not found"}, 404
+
+        logger.info(
+            "schedule_retrieved",
+            schedule_id=schedule_id,
+            tenant=tenant_id,
+        )
+
+        return (
+            {
+                "id": schedule_dto.id,
+                "tenant": schedule_dto.tenant,
+                "org_unit_id": schedule_dto.org_unit_id,
+                "test_type": schedule_dto.test_type,
+                "target": schedule_dto.target,
+                "interval_seconds": schedule_dto.interval_seconds,
+                "enabled": schedule_dto.enabled,
+                "created_at": schedule_dto.created_at.isoformat(),
+                "updated_at": schedule_dto.updated_at.isoformat(),
+                "meta": {
+                    "version": 1,
+                    "timestamp": datetime.now(timezone.utc).isoformat(),
+                },
+            },
+            200,
+        )
+
+    except Exception as e:
+        logger.error("get_schedule_failed", error=str(e))
+        return {"error": "Internal server error"}, 500
+
+
+@blueprint.route("/<schedule_id>", methods=["PUT"])
+@require_tenant
+@require_scope("schedules:write")
+@require_feature("waddleperf_client", "schedules")
+async def update_schedule(schedule_id: str) -> tuple[dict[str, Any], int]:
+    """Update a test schedule.
+
+    Args:
+        schedule_id: Schedule identifier
+
+    JSON body:
+        test_type: Test type (optional)
+        target: Test target (optional)
+        interval_seconds: Test interval in seconds (optional)
+        enabled: Whether schedule is enabled (optional)
+
+    Returns:
+        JSON response with updated schedule
+    """
+    try:
+        claims = current_claims()
+        if not claims:
+            return {"error": "Unauthorized"}, 403
+
+        tenant_id = claims["tenant"]
+        data = await request.get_json()
+
+        if not data:
+            return {"error": "Request body required"}, 400
+
+        db = get_db()
+        mgr = ScheduleManager(db, tenant_id)
+        await mgr.initialize()
+
+        schedule_dto = await mgr.update_schedule(schedule_id, data)
+
+        if not schedule_dto:
+            return {"error": "Schedule not found"}, 404
+
+        logger.info(
+            "schedule_updated",
+            schedule_id=schedule_id,
+            tenant=tenant_id,
+        )
+
+        return (
+            {
+                "id": schedule_dto.id,
+                "tenant": schedule_dto.tenant,
+                "org_unit_id": schedule_dto.org_unit_id,
+                "test_type": schedule_dto.test_type,
+                "target": schedule_dto.target,
+                "interval_seconds": schedule_dto.interval_seconds,
+                "enabled": schedule_dto.enabled,
+                "created_at": schedule_dto.created_at.isoformat(),
+                "updated_at": schedule_dto.updated_at.isoformat(),
+                "meta": {
+                    "version": 1,
+                    "timestamp": datetime.now(timezone.utc).isoformat(),
+                },
+            },
+            200,
+        )
+
+    except Exception as e:
+        logger.error("update_schedule_failed", error=str(e))
+        return {"error": "Internal server error"}, 500
+
+
+@blueprint.route("/<schedule_id>", methods=["DELETE"])
+@require_tenant
+@require_scope("schedules:write")
+@require_feature("waddleperf_client", "schedules")
+async def delete_schedule(schedule_id: str) -> tuple[dict[str, Any], int]:
+    """Delete a test schedule.
+
+    Args:
+        schedule_id: Schedule identifier
+
+    Returns:
+        JSON response with deletion status
+    """
+    try:
+        claims = current_claims()
+        if not claims:
+            return {"error": "Unauthorized"}, 403
+
+        tenant_id = claims["tenant"]
+        db = get_db()
+        mgr = ScheduleManager(db, tenant_id)
+        await mgr.initialize()
+
+        success = await mgr.delete_schedule(schedule_id)
+
+        if not success:
+            return {"error": "Schedule not found"}, 404
+
+        logger.info(
+            "schedule_deleted",
+            schedule_id=schedule_id,
+            tenant=tenant_id,
+        )
+
+        return (
+            {
+                "message": "Schedule deleted successfully",
+                "meta": {
+                    "version": 1,
+                    "timestamp": datetime.now(timezone.utc).isoformat(),
+                },
+            },
+            200,
+        )
+
+    except Exception as e:
+        logger.error("delete_schedule_failed", error=str(e))
+        return {"error": "Internal server error"}, 500

--- a/core/modules/waddleperf_client/api/version.py
+++ b/core/modules/waddleperf_client/api/version.py
@@ -1,0 +1,64 @@
+"""Version information REST API blueprint for WaddlePerf client."""
+from __future__ import annotations
+
+import structlog
+from datetime import datetime, timezone
+from typing import Any
+
+from quart import Blueprint, current_app, jsonify, request
+
+from core.auth.middleware import current_claims, require_tenant
+from core.entitlements.gate import require_feature
+
+logger = structlog.get_logger()
+
+blueprint = Blueprint("wpcl_version", __name__, url_prefix="/version")
+
+
+@blueprint.route("", methods=["GET"])
+@require_tenant
+@require_feature("waddleperf_client", "version")
+async def get_version() -> tuple[dict[str, Any], int]:
+    """Get the latest WaddlePerf client version information.
+
+    Required feature: waddleperf_client.version
+    No specific scope required (tenant access is sufficient).
+
+    Returns:
+        JSON response with version details and metadata
+    """
+    try:
+        claims = current_claims()
+        if not claims:
+            return {"error": "Unauthorized"}, 403
+
+        # Default version info
+        latest_version = current_app.config.get("WPCL_LATEST_VERSION", "1.0.0")
+        min_version = current_app.config.get("WPCL_MIN_VERSION", "0.1.0")
+        download_url = current_app.config.get(
+            "WPCL_DOWNLOAD_URL",
+            "https://downloads.tobogganing.app/waddleperf-client/latest",
+        )
+
+        logger.info(
+            "version_retrieved",
+            latest_version=latest_version,
+            tenant=claims["tenant"],
+        )
+
+        return (
+            {
+                "latest_version": latest_version,
+                "min_version": min_version,
+                "download_url": download_url,
+                "meta": {
+                    "version": 1,
+                    "timestamp": datetime.now(timezone.utc).isoformat(),
+                },
+            },
+            200,
+        )
+
+    except Exception as e:
+        logger.error("version_retrieval_failed", error=str(e))
+        return {"error": "Internal server error"}, 500

--- a/core/modules/waddleperf_client/services/__init__.py
+++ b/core/modules/waddleperf_client/services/__init__.py
@@ -1,0 +1,1 @@
+"""WaddlePerf client service managers (penguin-dal, tenant-scoped)."""

--- a/core/modules/waddleperf_client/services/schedule_manager.py
+++ b/core/modules/waddleperf_client/services/schedule_manager.py
@@ -1,0 +1,291 @@
+"""Test schedule management for WaddlePerf client."""
+from __future__ import annotations
+
+import asyncio
+import structlog
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Optional
+
+logger = structlog.get_logger()
+
+
+@dataclass(slots=True)
+class TestScheduleDTO:
+    """Test schedule data transfer object."""
+
+    id: str
+    tenant: str
+    org_unit_id: str | None
+    test_type: str
+    target: str
+    interval_seconds: int
+    enabled: bool
+    created_at: datetime
+    updated_at: datetime
+
+
+class ScheduleManager:
+    """Manages test schedules for WaddlePerf client using penguin-dal."""
+
+    def __init__(self, db: object, tenant_id: str) -> None:
+        """Initialize ScheduleManager.
+
+        Args:
+            db: penguin-dal DAL instance
+            tenant_id: Tenant identifier for scoping queries
+        """
+        self.db = db
+        self.tenant_id = tenant_id
+        self._lock = asyncio.Lock()
+
+    async def initialize(self) -> None:
+        """Initialize the ScheduleManager."""
+        try:
+            logger.info("ScheduleManager initialized", tenant=self.tenant_id)
+        except Exception as e:
+            logger.error("Failed to initialize ScheduleManager", error=str(e))
+            raise
+
+    async def shutdown(self) -> None:
+        """Shutdown the ScheduleManager."""
+        logger.info("ScheduleManager shutdown complete")
+
+    async def create_schedule(self, data: dict) -> TestScheduleDTO:
+        """Create a new test schedule.
+
+        Args:
+            data: Schedule data (org_unit_id, test_type, target, interval_seconds, enabled)
+
+        Returns:
+            TestScheduleDTO object
+        """
+        async with self._lock:
+            schedule_obj = await asyncio.to_thread(
+                self.db.test_schedules.create,
+                tenant=self.tenant_id,
+                org_unit_id=data.get("org_unit_id"),
+                test_type=data.get("test_type"),
+                target=data.get("target"),
+                interval_seconds=data.get("interval_seconds"),
+                enabled=data.get("enabled", True),
+            )
+
+            logger.info(
+                "created_schedule",
+                schedule_id=schedule_obj.id,
+                test_type=schedule_obj.test_type,
+                tenant=self.tenant_id,
+            )
+
+            return TestScheduleDTO(
+                id=schedule_obj.id,
+                tenant=schedule_obj.tenant,
+                org_unit_id=schedule_obj.org_unit_id,
+                test_type=schedule_obj.test_type,
+                target=schedule_obj.target,
+                interval_seconds=schedule_obj.interval_seconds,
+                enabled=schedule_obj.enabled,
+                created_at=schedule_obj.created_at,
+                updated_at=schedule_obj.updated_at,
+            )
+
+    async def get_schedule(self, schedule_id: str) -> TestScheduleDTO | None:
+        """Get a test schedule by ID.
+
+        Args:
+            schedule_id: Schedule identifier
+
+        Returns:
+            TestScheduleDTO or None if not found
+        """
+        schedule_obj = await asyncio.to_thread(
+            self.db.test_schedules.select,
+            id=schedule_id,
+            tenant=self.tenant_id,
+        )
+        if not schedule_obj:
+            return None
+
+        return TestScheduleDTO(
+            id=schedule_obj.id,
+            tenant=schedule_obj.tenant,
+            org_unit_id=schedule_obj.org_unit_id,
+            test_type=schedule_obj.test_type,
+            target=schedule_obj.target,
+            interval_seconds=schedule_obj.interval_seconds,
+            enabled=schedule_obj.enabled,
+            created_at=schedule_obj.created_at,
+            updated_at=schedule_obj.updated_at,
+        )
+
+    async def list_schedules(
+        self,
+        org_unit_id: str | None = None,
+        limit: int = 100,
+        offset: int = 0,
+    ) -> list[TestScheduleDTO]:
+        """List test schedules for the tenant.
+
+        Args:
+            org_unit_id: Optional org unit ID for filtering
+            limit: Maximum number of results
+            offset: Offset for pagination
+
+        Returns:
+            List of TestScheduleDTO objects
+        """
+        if org_unit_id is not None:
+            schedules = await asyncio.to_thread(
+                self.db.test_schedules.select_list,
+                tenant=self.tenant_id,
+                org_unit_id=org_unit_id,
+                limitby=(offset, offset + limit),
+            )
+        else:
+            schedules = await asyncio.to_thread(
+                self.db.test_schedules.select_list,
+                tenant=self.tenant_id,
+                limitby=(offset, offset + limit),
+            )
+
+        return [
+            TestScheduleDTO(
+                id=s.id,
+                tenant=s.tenant,
+                org_unit_id=s.org_unit_id,
+                test_type=s.test_type,
+                target=s.target,
+                interval_seconds=s.interval_seconds,
+                enabled=s.enabled,
+                created_at=s.created_at,
+                updated_at=s.updated_at,
+            )
+            for s in schedules
+        ]
+
+    async def update_schedule(self, schedule_id: str, data: dict) -> TestScheduleDTO | None:
+        """Update a test schedule.
+
+        Args:
+            schedule_id: Schedule identifier
+            data: Updated schedule data
+
+        Returns:
+            Updated TestScheduleDTO or None if not found
+        """
+        existing = await self.get_schedule(schedule_id)
+        if not existing:
+            return None
+
+        async with self._lock:
+            update_data = {
+                k: v
+                for k, v in data.items()
+                if k in ["test_type", "target", "interval_seconds", "enabled"]
+            }
+            update_data["updated_at"] = datetime.now(timezone.utc)
+
+            await asyncio.to_thread(
+                self.db.test_schedules.update,
+                id=schedule_id,
+                tenant=self.tenant_id,
+                **update_data,
+            )
+
+            logger.info(
+                "updated_schedule",
+                schedule_id=schedule_id,
+                tenant=self.tenant_id,
+            )
+
+        return await self.get_schedule(schedule_id)
+
+    async def delete_schedule(self, schedule_id: str) -> bool:
+        """Delete a test schedule.
+
+        Args:
+            schedule_id: Schedule identifier
+
+        Returns:
+            True if successful, False if not found
+        """
+        existing = await self.get_schedule(schedule_id)
+        if not existing:
+            return False
+
+        async with self._lock:
+            await asyncio.to_thread(
+                self.db.test_schedules.delete,
+                id=schedule_id,
+                tenant=self.tenant_id,
+            )
+
+            logger.info(
+                "deleted_schedule",
+                schedule_id=schedule_id,
+                tenant=self.tenant_id,
+            )
+
+        return True
+
+    async def resolve_for_device(self, device: object) -> list[TestScheduleDTO]:
+        """Resolve enabled test schedules applicable to a device.
+
+        Returns schedules that are either:
+        - Specific to the device's org_unit_id and enabled
+        - Tenant-wide (org_unit_id is None) and enabled
+
+        Args:
+            device: Device object with org_unit_id attribute
+
+        Returns:
+            List of applicable enabled TestScheduleDTO objects
+        """
+        # Query org-unit-specific schedules
+        ou_schedules = await asyncio.to_thread(
+            self.db.test_schedules.select_list,
+            tenant=self.tenant_id,
+            org_unit_id=device.org_unit_id,
+            enabled=True,
+        )
+
+        # Query tenant-wide schedules (org_unit_id is None)
+        tenant_wide_schedules = await asyncio.to_thread(
+            self.db.test_schedules.select_list,
+            tenant=self.tenant_id,
+            org_unit_id=None,
+            enabled=True,
+        )
+
+        # Combine and deduplicate by id
+        all_schedules = list(ou_schedules) + list(tenant_wide_schedules)
+        seen_ids = set()
+        result = []
+
+        for s in all_schedules:
+            if s.id not in seen_ids:
+                seen_ids.add(s.id)
+                result.append(
+                    TestScheduleDTO(
+                        id=s.id,
+                        tenant=s.tenant,
+                        org_unit_id=s.org_unit_id,
+                        test_type=s.test_type,
+                        target=s.target,
+                        interval_seconds=s.interval_seconds,
+                        enabled=s.enabled,
+                        created_at=s.created_at,
+                        updated_at=s.updated_at,
+                    )
+                )
+
+        logger.info(
+            "resolved_schedules_for_device",
+            device_id=device.id,
+            org_unit_id=device.org_unit_id,
+            schedule_count=len(result),
+            tenant=self.tenant_id,
+        )
+
+        return result

--- a/core/tests/conftest.py
+++ b/core/tests/conftest.py
@@ -345,7 +345,7 @@ def app_with_wpc(app: Quart, mock_db: MagicMock, monkeypatch: Any) -> Quart:
     original_flag_on = shared.licensing.entitlements._flag_on
 
     def mock_flag_on(flag_key: str, distinct_id: str = "system") -> bool:
-        if flag_key.startswith("tobogganing.waddleperf_cluster."):
+        if flag_key.startswith("tobogganing.waddleperf_cluster.") or flag_key.startswith("tobogganing.waddleperf_client."):
             return True
         return original_flag_on(flag_key, distinct_id)
 
@@ -353,9 +353,12 @@ def app_with_wpc(app: Quart, mock_db: MagicMock, monkeypatch: Any) -> Quart:
 
     # Register WaddlePerf Cluster module via registry (REAL auth, no monkeypatch)
     from core.modules.waddleperf_cluster import module as wpc_module
+    from core.modules.waddleperf_client import module as wpcl_module
 
     wpc_contract = wpc_module()
+    wpcl_contract = wpcl_module()
     app.registry.register(wpc_contract)
+    app.registry.register(wpcl_contract)
 
     # Apply registry to wire blueprints
     ctx = ModuleContext(config=app.config_obj, db=mock_db, key_provider=provider)
@@ -435,7 +438,7 @@ def wpc_readonly_token(app_with_wpc: Quart) -> str:
         "iss": "test-app",
         "aud": "test-app",
         "tenant": "test-tenant",
-        "scope": "org_units:read devices:read tests:read stats:read",
+        "scope": "org_units:read devices:read tests:read stats:read schedules:read config:read version:read",
     }
 
     token = encode_access_token(claims, provider, ttl_hours=1)

--- a/core/tests/test_migrations_head.py
+++ b/core/tests/test_migrations_head.py
@@ -21,6 +21,7 @@ from core.db.models import (
     PerfTestResult,
     ClientConfig,
     ServerKey,
+    TestSchedule,
 )
 from core.modules.sase.security.scanner.models import (
     SecurityScan,
@@ -39,7 +40,7 @@ from core.modules.sase.security.feeds.models import (
 
 
 def test_alembic_migrations_cover_all_tables() -> None:
-    """Verify all Base.metadata tables are covered by migrations 0001-0012.
+    """Verify all Base.metadata tables are covered by migrations 0001-0013.
 
     Migration 0001: users, refresh_tokens, password_reset_tokens
     Migration 0002: firewall_rules
@@ -55,6 +56,7 @@ def test_alembic_migrations_cover_all_tables() -> None:
     Migration 0010: org_units
     Migration 0011: devices, device_api_keys, device_enrollment_secrets
     Migration 0012: perf_test_results, client_configs, server_keys
+    Migration 0013: test_schedules
     """
     # Get expected tables from Base.metadata
     expected_tables = set(Base.metadata.tables.keys())
@@ -86,7 +88,7 @@ def test_alembic_migrations_cover_all_tables() -> None:
         "threat_detections",
     }
 
-    # Tables created by migrations 0010-0012 (WaddlePerf cluster tables)
+    # Tables created by migrations 0010-0013 (WaddlePerf cluster tables)
     created_by_wpc_migrations = {
         "org_units",
         "devices",
@@ -95,6 +97,7 @@ def test_alembic_migrations_cover_all_tables() -> None:
         "perf_test_results",
         "client_configs",
         "server_keys",
+        "test_schedules",
     }
 
     # All tables covered by migrations
@@ -133,6 +136,7 @@ def test_base_metadata_models_imported() -> None:
         PerfTestResult,
         ClientConfig,
         ServerKey,
+        TestSchedule,
         SecurityScan,
         SecurityFinding,
         ScanSchedule,

--- a/core/tests/test_wpcl_config.py
+++ b/core/tests/test_wpcl_config.py
@@ -1,0 +1,388 @@
+"""Tests for WaddlePerf client config API endpoints."""
+from __future__ import annotations
+
+import asyncio
+import pytest
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, MagicMock, patch
+from quart import Quart
+from typing import Any
+
+from core.modules.waddleperf_client.services.schedule_manager import TestScheduleDTO
+
+
+def make_mock_schedule(
+    schedule_id: str = "test-sched-1",
+    test_type: str = "ping",
+    target: str = "example.com",
+    interval_seconds: int = 60,
+) -> TestScheduleDTO:
+    """Create a mock TestScheduleDTO."""
+    return TestScheduleDTO(
+        id=schedule_id,
+        tenant="test-tenant",
+        org_unit_id="ou-1",
+        test_type=test_type,
+        target=target,
+        interval_seconds=interval_seconds,
+        enabled=True,
+        created_at=datetime.now(timezone.utc),
+        updated_at=datetime.now(timezone.utc),
+    )
+
+
+def make_mock_device(
+    device_id: str = "dev-123",
+    org_unit_id: str = "ou-1",
+) -> MagicMock:
+    """Create a mock device object."""
+    device = MagicMock()
+    device.id = device_id
+    device.org_unit_id = org_unit_id
+    device.tenant = "test-tenant"
+    device.name = "test-device"
+    device.serial = "ABC123"
+    return device
+
+
+# Use fixtures from conftest: app_with_wpc
+
+
+@pytest.mark.asyncio
+async def test_get_client_config_success(app_with_wpc: Quart) -> None:
+    """Test successful client config retrieval with valid device key.
+
+    Args:
+        app_with_wpc: Test app with WPC module.
+    """
+    client = app_with_wpc.test_client()
+    test_api_key = "test-device-key-12345"
+
+    with patch(
+        "core.modules.waddleperf_client.api.client_config.authenticate_device_global",
+        new_callable=AsyncMock
+    ) as mock_auth, patch(
+        "core.modules.waddleperf_client.api.client_config.ScheduleManager"
+    ) as mock_mgr_class, patch(
+        "core.modules.waddleperf_client.api.client_config.get_db"
+    ) as mock_get_db:
+
+        device = make_mock_device()
+        mock_auth.return_value = (device, "test-tenant")
+
+        mock_mgr = AsyncMock()
+        mock_mgr_class.return_value = mock_mgr
+        mock_mgr.initialize = AsyncMock()
+
+        schedules = [make_mock_schedule(schedule_id="sched-1")]
+        mock_mgr.resolve_for_device = AsyncMock(return_value=schedules)
+
+        mock_db = MagicMock()
+        mock_db.client_configs = MagicMock()
+        mock_db.client_configs.select_list = MagicMock(return_value=None)
+        mock_get_db.return_value = mock_db
+
+        response = await client.get(
+            "/api/v1/waddleperf_client/config",
+            headers={"Authorization": f"Bearer {test_api_key}"},
+        )
+
+        assert response.status_code == 200
+        data = await response.get_json()
+        assert len(data["schedules"]) == 1
+        assert data["schedules"][0]["id"] == "sched-1"
+        assert "config" in data
+        assert "meta" in data
+        assert data["meta"]["version"] == 1
+
+
+@pytest.mark.asyncio
+async def test_get_client_config_returns_resolved_schedules(
+    app_with_wpc: Quart,
+) -> None:
+    """Test that client config returns schedules resolved for device's org unit.
+
+    Args:
+        app_with_wpc: Test app with WPC module.
+    """
+    client = app_with_wpc.test_client()
+    test_api_key = "test-device-key-12345"
+
+    with patch(
+        "core.modules.waddleperf_client.api.client_config.authenticate_device_global"
+    ) as mock_auth, patch(
+        "core.modules.waddleperf_client.api.client_config.ScheduleManager"
+    ) as mock_mgr_class, patch(
+        "core.modules.waddleperf_client.api.client_config.get_db"
+    ) as mock_get_db:
+
+        device = make_mock_device(device_id="dev-456", org_unit_id="ou-2")
+        mock_auth.return_value = (device, "test-tenant")
+
+        mock_mgr = AsyncMock()
+        mock_mgr_class.return_value = mock_mgr
+        mock_mgr.initialize = AsyncMock()
+
+        schedules = [
+            make_mock_schedule(schedule_id="sched-ou2-1"),
+            make_mock_schedule(schedule_id="sched-ou2-2"),
+        ]
+        mock_mgr.resolve_for_device = AsyncMock(return_value=schedules)
+
+        mock_db = MagicMock()
+        mock_db.client_configs = MagicMock()
+        mock_db.client_configs.select_list = MagicMock(return_value=None)
+        mock_get_db.return_value = mock_db
+
+        response = await client.get(
+            "/api/v1/waddleperf_client/config",
+            headers={"Authorization": f"Bearer {test_api_key}"},
+        )
+
+        assert response.status_code == 200
+        data = await response.get_json()
+        assert len(data["schedules"]) == 2
+
+        # Verify resolve_for_device was called with the device
+        mock_mgr.resolve_for_device.assert_called_once_with(device)
+
+
+@pytest.mark.asyncio
+async def test_get_client_config_includes_client_config(
+    app_with_wpc: Quart,
+) -> None:
+    """Test that client config includes fetched config from DB.
+
+    Args:
+        app_with_wpc: Test app with WPC module.
+    """
+    client = app_with_wpc.test_client()
+    test_api_key = "test-device-key-12345"
+
+    with patch(
+        "core.modules.waddleperf_client.api.client_config.authenticate_device_global"
+    ) as mock_auth, patch(
+        "core.modules.waddleperf_client.api.client_config.ScheduleManager"
+    ) as mock_mgr_class, patch(
+        "core.modules.waddleperf_client.api.client_config.get_db"
+    ) as mock_get_db:
+
+        device = make_mock_device()
+        mock_auth.return_value = (device, "test-tenant")
+
+        mock_mgr = AsyncMock()
+        mock_mgr_class.return_value = mock_mgr
+        mock_mgr.initialize = AsyncMock()
+        mock_mgr.resolve_for_device = AsyncMock(return_value=[])
+
+        mock_db = MagicMock()
+        config_obj = MagicMock()
+        config_obj.config = {"test_mode": True, "verbose": False}
+        mock_db.client_configs.select_list = MagicMock(return_value=[config_obj])
+        mock_get_db.return_value = mock_db
+
+        response = await client.get(
+            "/api/v1/waddleperf_client/config",
+            headers={"Authorization": f"Bearer {test_api_key}"},
+        )
+
+        assert response.status_code == 200
+        data = await response.get_json()
+        assert data["config"] == {"test_mode": True, "verbose": False}
+
+
+@pytest.mark.asyncio
+async def test_get_client_config_missing_auth_header(app_with_wpc: Quart) -> None:
+    """Test config retrieval fails without Authorization header.
+
+    Args:
+        app_with_wpc: Test app with WPC module.
+    """
+    client = app_with_wpc.test_client()
+
+    response = await client.get("/api/v1/waddleperf_client/config")
+
+    assert response.status_code == 401
+    data = await response.get_json()
+    assert "Missing or invalid Authorization header" in data["error"]
+
+
+@pytest.mark.asyncio
+async def test_get_client_config_invalid_device_key(app_with_wpc: Quart) -> None:
+    """Test config retrieval fails with invalid device key.
+
+    Args:
+        app_with_wpc: Test app with WPC module.
+    """
+    client = app_with_wpc.test_client()
+
+    with patch(
+        "core.modules.waddleperf_client.api.client_config.authenticate_device_global"
+    ) as mock_auth:
+        mock_auth.return_value = None
+
+        response = await client.get(
+            "/api/v1/waddleperf_client/config",
+            headers={"Authorization": "Bearer invalid-key"},
+        )
+
+        assert response.status_code == 401
+        data = await response.get_json()
+        assert "Invalid device credentials" in data["error"]
+
+
+@pytest.mark.asyncio
+async def test_get_client_config_feature_disabled(app_with_wpc: Quart) -> None:
+    """Test config retrieval returns 402 when feature flag is disabled.
+
+    Args:
+        app_with_wpc: Test app with WPC module.
+    """
+    client = app_with_wpc.test_client()
+    test_api_key = "test-device-key-12345"
+
+    with patch(
+        "core.modules.waddleperf_client.api.client_config.authenticate_device_global"
+    ) as mock_auth, patch(
+        "core.modules.waddleperf_client.api.client_config.feature_enabled"
+    ) as mock_feature:
+
+        device = make_mock_device()
+        mock_auth.return_value = (device, "test-tenant")
+        mock_feature.return_value = False
+
+        response = await client.get(
+            "/api/v1/waddleperf_client/config",
+            headers={"Authorization": f"Bearer {test_api_key}"},
+        )
+
+        assert response.status_code == 402
+        data = await response.get_json()
+        assert "Feature not available" in data["error"]
+
+
+@pytest.mark.asyncio
+async def test_get_client_config_tenant_derived_from_device(
+    app_with_wpc: Quart,
+) -> None:
+    """Test that tenant is derived from device record, not header.
+
+    Args:
+        app_with_wpc: Test app with WPC module.
+    """
+    client = app_with_wpc.test_client()
+    test_api_key = "test-device-key-12345"
+
+    with patch(
+        "core.modules.waddleperf_client.api.client_config.authenticate_device_global"
+    ) as mock_auth, patch(
+        "core.modules.waddleperf_client.api.client_config.ScheduleManager"
+    ) as mock_mgr_class, patch(
+        "core.modules.waddleperf_client.api.client_config.get_db"
+    ) as mock_get_db:
+
+        device = make_mock_device()
+        # Device's tenant is "test-tenant"
+        mock_auth.return_value = (device, "test-tenant")
+
+        mock_mgr = AsyncMock()
+        mock_mgr_class.return_value = mock_mgr
+        mock_mgr.initialize = AsyncMock()
+        mock_mgr.resolve_for_device = AsyncMock(return_value=[])
+
+        mock_db = MagicMock()
+        mock_db.client_configs.select_list = MagicMock(return_value=None)
+        mock_get_db.return_value = mock_db
+
+        response = await client.get(
+            "/api/v1/waddleperf_client/config",
+            headers={"Authorization": f"Bearer {test_api_key}"},
+        )
+
+        assert response.status_code == 200
+
+        # Verify ScheduleManager was created with tenant from device, not header
+        mock_mgr_class.assert_called_once_with(mock_db, "test-tenant")
+
+
+@pytest.mark.asyncio
+async def test_get_client_config_revoked_key(app_with_wpc: Quart) -> None:
+    """Test config retrieval fails with revoked device key.
+
+    Args:
+        app_with_wpc: Test app with WPC module.
+    """
+    client = app_with_wpc.test_client()
+
+    with patch(
+        "core.modules.waddleperf_client.api.client_config.authenticate_device_global"
+    ) as mock_auth:
+        # authenticate_device_global returns None for revoked keys
+        mock_auth.return_value = None
+
+        response = await client.get(
+            "/api/v1/waddleperf_client/config",
+            headers={"Authorization": "Bearer revoked-key"},
+        )
+
+        assert response.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_get_client_config_empty_schedules(app_with_wpc: Quart) -> None:
+    """Test config retrieval with no schedules resolved.
+
+    Args:
+        app_with_wpc: Test app with WPC module.
+    """
+    client = app_with_wpc.test_client()
+    test_api_key = "test-device-key-12345"
+
+    with patch(
+        "core.modules.waddleperf_client.api.client_config.authenticate_device_global"
+    ) as mock_auth, patch(
+        "core.modules.waddleperf_client.api.client_config.ScheduleManager"
+    ) as mock_mgr_class, patch(
+        "core.modules.waddleperf_client.api.client_config.get_db"
+    ) as mock_get_db:
+
+        device = make_mock_device()
+        mock_auth.return_value = (device, "test-tenant")
+
+        mock_mgr = AsyncMock()
+        mock_mgr_class.return_value = mock_mgr
+        mock_mgr.initialize = AsyncMock()
+        mock_mgr.resolve_for_device = AsyncMock(return_value=[])
+
+        mock_db = MagicMock()
+        mock_db.client_configs.select_list = MagicMock(return_value=None)
+        mock_get_db.return_value = mock_db
+
+        response = await client.get(
+            "/api/v1/waddleperf_client/config",
+            headers={"Authorization": f"Bearer {test_api_key}"},
+        )
+
+        assert response.status_code == 200
+        data = await response.get_json()
+        assert data["schedules"] == []
+        assert data["config"] == {}
+
+
+@pytest.mark.asyncio
+async def test_get_client_config_no_bearer_prefix(app_with_wpc: Quart) -> None:
+    """Test config retrieval fails with malformed Authorization header.
+
+    Args:
+        app_with_wpc: Test app with WPC module.
+    """
+    client = app_with_wpc.test_client()
+
+    response = await client.get(
+        "/api/v1/waddleperf_client/config",
+        headers={"Authorization": "Basic dGVzdDp0ZXN0"},
+    )
+
+    assert response.status_code == 401
+    data = await response.get_json()
+    assert "Missing or invalid Authorization header" in data["error"]

--- a/core/tests/test_wpcl_contract.py
+++ b/core/tests/test_wpcl_contract.py
@@ -1,0 +1,72 @@
+"""Tests for waddleperf_client module registration and URL mapping contract."""
+from __future__ import annotations
+
+import pytest
+from quart import Quart
+
+
+@pytest.mark.asyncio
+async def test_wpcl_module_registered(app_with_wpc: Quart) -> None:
+    """waddleperf_client declares its flags on the registry.
+
+    Args:
+        app_with_wpc: Test app with the WaddlePerf modules registered.
+    """
+    registry = app_with_wpc.registry
+    assert registry is not None
+
+    flags = registry.declared_flags()
+    assert "tobogganing.waddleperf_client.schedules" in flags
+    assert "tobogganing.waddleperf_client.config" in flags
+    assert "tobogganing.waddleperf_client.version" in flags
+
+
+@pytest.mark.asyncio
+async def test_wpcl_routes_mounted(app_with_wpc: Quart) -> None:
+    """All waddleperf_client routes resolve (auth error, not 404).
+
+    Args:
+        app_with_wpc: Test app with the WaddlePerf modules registered.
+    """
+    client = app_with_wpc.test_client()
+    routes_to_check = [
+        "/api/v1/waddleperf_client/schedules",
+        "/api/v1/waddleperf_client/config",
+        "/api/v1/waddleperf_client/version",
+    ]
+    for route in routes_to_check:
+        response = await client.get(route)
+        assert response.status_code != 404, (
+            f"Route {route} not mounted (got 404)"
+        )
+
+
+@pytest.mark.asyncio
+async def test_wpcl_feature_flags_default_off() -> None:
+    """The module contract declares exactly the expected flag keys."""
+    from core.modules.waddleperf_client import module as wpcl_module
+
+    contract = wpcl_module()
+    flag_leaves = [f.split(".")[-1] for f in contract.flags]
+    for flag in ["schedules", "config", "version"]:
+        assert flag in flag_leaves
+    assert contract.migrations == ["0013"]
+    # All client features are community tier.
+    for ent in contract.entitlements:
+        assert ent.tier == "community"
+
+
+@pytest.mark.asyncio
+async def test_other_modules_unaffected(app_with_wpc: Quart) -> None:
+    """Registering waddleperf_client leaves sase/ping/cluster routes intact.
+
+    Args:
+        app_with_wpc: Test app with the WaddlePerf modules registered.
+    """
+    client = app_with_wpc.test_client()
+    for route in [
+        "/api/v1/ping",
+        "/api/v1/waddleperf_cluster/org-units",
+    ]:
+        response = await client.get(route)
+        assert response.status_code != 404, f"Route {route} unexpectedly missing"

--- a/core/tests/test_wpcl_models.py
+++ b/core/tests/test_wpcl_models.py
@@ -1,0 +1,118 @@
+"""Test TestSchedule model creation and schema."""
+from __future__ import annotations
+
+from uuid import uuid4
+import pytest
+from sqlalchemy import create_engine, inspect
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from core.db.base import Base
+from core.db.models import TestSchedule
+
+
+@pytest.fixture
+def test_engine():
+    """Create a fresh in-memory SQLite engine for each test."""
+    engine = create_engine(
+        "sqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    yield engine
+    engine.dispose()
+
+
+def test_test_schedule_model_creates_table(test_engine) -> None:
+    """Verify TestSchedule model creates the test_schedules table."""
+    TestSchedule.__table__.create(test_engine, checkfirst=True)
+
+    inspector = inspect(test_engine)
+    tables = inspector.get_table_names()
+
+    assert "test_schedules" in tables, "test_schedules table not created"
+
+
+def test_test_schedule_table_structure(test_engine) -> None:
+    """Verify test_schedules table has correct columns."""
+    TestSchedule.__table__.create(test_engine, checkfirst=True)
+
+    inspector = inspect(test_engine)
+    columns = {col["name"]: col for col in inspector.get_columns("test_schedules")}
+
+    # Verify columns exist
+    expected_columns = {
+        "id",
+        "tenant",
+        "org_unit_id",
+        "test_type",
+        "target",
+        "interval_seconds",
+        "enabled",
+        "created_at",
+        "updated_at",
+    }
+    actual_columns = set(columns.keys())
+    assert (
+        expected_columns == actual_columns
+    ), f"Column mismatch. Expected {expected_columns}, got {actual_columns}"
+
+    # Verify key properties
+    assert columns["id"]["nullable"] is False, "id should not be nullable"
+    assert columns["tenant"]["nullable"] is False, "tenant should not be nullable"
+    assert columns["interval_seconds"]["nullable"] is False, "interval_seconds should not be nullable"
+    assert columns["enabled"]["nullable"] is False, "enabled should not be nullable"
+    assert columns["org_unit_id"]["nullable"] is True, "org_unit_id should be nullable"
+
+
+def test_test_schedule_indexes(test_engine) -> None:
+    """Verify test_schedules table has expected indexes from model.
+
+    Note: Create_table() creates column-level indexes (index=True),
+    but not the migration-defined composite index ix_test_schedules_tenant_ou.
+    That index is created by the migration (0013_wpc_test_schedules.py).
+    """
+    TestSchedule.__table__.create(test_engine, checkfirst=True)
+
+    inspector = inspect(test_engine)
+    indexes = inspector.get_indexes("test_schedules")
+
+    # Check for tenant index (created by Column(index=True) on tenant column)
+    tenant_index_found = False
+
+    for idx in indexes:
+        if "tenant" in idx["column_names"]:
+            tenant_index_found = True
+            break
+
+    assert tenant_index_found, "No tenant index found on tenant column"
+
+
+def test_test_schedule_repr() -> None:
+    """Verify TestSchedule __repr__ works correctly."""
+    test_id = str(uuid4())
+    ou_id = str(uuid4())
+
+    schedule = TestSchedule(
+        id=test_id,
+        tenant="test-tenant",
+        org_unit_id=ou_id,
+        test_type="latency",
+        target="example.com",
+        interval_seconds=300,
+        enabled=True,
+    )
+
+    repr_str = repr(schedule)
+    assert "TestSchedule" in repr_str
+    assert test_id in repr_str
+    assert "test-tenant" in repr_str
+    assert "latency" in repr_str
+
+
+def test_test_schedule_base_metadata_included() -> None:
+    """Verify TestSchedule is included in Base.metadata."""
+    assert (
+        "test_schedules" in Base.metadata.tables
+    ), "test_schedules table not in Base.metadata"
+    assert TestSchedule.__tablename__ == "test_schedules"

--- a/core/tests/test_wpcl_schedule_manager.py
+++ b/core/tests/test_wpcl_schedule_manager.py
@@ -1,0 +1,457 @@
+"""Test ScheduleManager CRUD and tenant scoping."""
+from __future__ import annotations
+
+import pytest
+from unittest.mock import MagicMock
+from datetime import datetime, timezone
+
+from core.modules.waddleperf_client.services.schedule_manager import (
+    ScheduleManager,
+    TestScheduleDTO,
+)
+
+
+def make_mock_schedule(data: dict) -> MagicMock:
+    """Create a mock schedule object."""
+    schedule = MagicMock()
+    for key, value in data.items():
+        setattr(schedule, key, value)
+    schedule.as_dict.return_value = data
+    return schedule
+
+
+@pytest.mark.asyncio
+async def test_schedule_manager_create_schedule() -> None:
+    """Test creating a schedule."""
+    db = MagicMock()
+    now = datetime.now(timezone.utc)
+    mock_schedule = make_mock_schedule(
+        {
+            "id": "sched-123",
+            "tenant": "tenant-1",
+            "org_unit_id": "ou-456",
+            "test_type": "latency",
+            "target": "example.com",
+            "interval_seconds": 300,
+            "enabled": True,
+            "created_at": now,
+            "updated_at": now,
+        }
+    )
+    db.test_schedules.create = MagicMock(return_value=mock_schedule)
+
+    manager = ScheduleManager(db, "tenant-1")
+    await manager.initialize()
+
+    result = await manager.create_schedule(
+        {
+            "org_unit_id": "ou-456",
+            "test_type": "latency",
+            "target": "example.com",
+            "interval_seconds": 300,
+            "enabled": True,
+        }
+    )
+
+    assert result.id == "sched-123"
+    assert result.tenant == "tenant-1"
+    assert result.test_type == "latency"
+    assert result.target == "example.com"
+    assert result.interval_seconds == 300
+    assert result.enabled is True
+
+    # Verify tenant was passed
+    db.test_schedules.create.assert_called_once()
+    call_kwargs = db.test_schedules.create.call_args[1]
+    assert call_kwargs["tenant"] == "tenant-1"
+
+
+@pytest.mark.asyncio
+async def test_schedule_manager_get_schedule() -> None:
+    """Test getting a schedule by ID."""
+    db = MagicMock()
+    now = datetime.now(timezone.utc)
+    mock_schedule = make_mock_schedule(
+        {
+            "id": "sched-123",
+            "tenant": "tenant-1",
+            "org_unit_id": "ou-456",
+            "test_type": "latency",
+            "target": "example.com",
+            "interval_seconds": 300,
+            "enabled": True,
+            "created_at": now,
+            "updated_at": now,
+        }
+    )
+    db.test_schedules.select = MagicMock(return_value=mock_schedule)
+
+    manager = ScheduleManager(db, "tenant-1")
+    await manager.initialize()
+
+    result = await manager.get_schedule("sched-123")
+
+    assert result is not None
+    assert result.id == "sched-123"
+    assert result.tenant == "tenant-1"
+
+    # Verify tenant scoping
+    db.test_schedules.select.assert_called_once_with(
+        id="sched-123", tenant="tenant-1"
+    )
+
+
+@pytest.mark.asyncio
+async def test_schedule_manager_get_schedule_not_found() -> None:
+    """Test getting a non-existent schedule."""
+    db = MagicMock()
+    db.test_schedules.select = MagicMock(return_value=None)
+
+    manager = ScheduleManager(db, "tenant-1")
+    await manager.initialize()
+
+    result = await manager.get_schedule("nonexistent")
+
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_schedule_manager_list_schedules() -> None:
+    """Test listing schedules."""
+    db = MagicMock()
+    now = datetime.now(timezone.utc)
+    mock_schedules = [
+        make_mock_schedule(
+            {
+                "id": "sched-1",
+                "tenant": "tenant-1",
+                "org_unit_id": "ou-456",
+                "test_type": "latency",
+                "target": "example.com",
+                "interval_seconds": 300,
+                "enabled": True,
+                "created_at": now,
+                "updated_at": now,
+            }
+        ),
+        make_mock_schedule(
+            {
+                "id": "sched-2",
+                "tenant": "tenant-1",
+                "org_unit_id": "ou-456",
+                "test_type": "throughput",
+                "target": "example.com",
+                "interval_seconds": 600,
+                "enabled": True,
+                "created_at": now,
+                "updated_at": now,
+            }
+        ),
+    ]
+    db.test_schedules.select_list = MagicMock(return_value=mock_schedules)
+
+    manager = ScheduleManager(db, "tenant-1")
+    await manager.initialize()
+
+    result = await manager.list_schedules(org_unit_id="ou-456")
+
+    assert len(result) == 2
+    assert result[0].id == "sched-1"
+    assert result[1].id == "sched-2"
+
+    # Verify tenant and org_unit_id scoping
+    db.test_schedules.select_list.assert_called_once()
+    call_kwargs = db.test_schedules.select_list.call_args[1]
+    assert call_kwargs["tenant"] == "tenant-1"
+    assert call_kwargs["org_unit_id"] == "ou-456"
+
+
+@pytest.mark.asyncio
+async def test_schedule_manager_list_schedules_tenant_wide() -> None:
+    """Test listing tenant-wide schedules."""
+    db = MagicMock()
+    now = datetime.now(timezone.utc)
+    mock_schedules = [
+        make_mock_schedule(
+            {
+                "id": "sched-1",
+                "tenant": "tenant-1",
+                "org_unit_id": None,
+                "test_type": "latency",
+                "target": "example.com",
+                "interval_seconds": 300,
+                "enabled": True,
+                "created_at": now,
+                "updated_at": now,
+            }
+        ),
+    ]
+    db.test_schedules.select_list = MagicMock(return_value=mock_schedules)
+
+    manager = ScheduleManager(db, "tenant-1")
+    await manager.initialize()
+
+    result = await manager.list_schedules()
+
+    assert len(result) == 1
+    assert result[0].org_unit_id is None
+
+    # Verify tenant scoping but no org_unit_id filter
+    call_kwargs = db.test_schedules.select_list.call_args[1]
+    assert call_kwargs["tenant"] == "tenant-1"
+
+
+@pytest.mark.asyncio
+async def test_schedule_manager_update_schedule() -> None:
+    """Test updating a schedule."""
+    db = MagicMock()
+    now = datetime.now(timezone.utc)
+
+    # Mock for get_schedule calls
+    original = make_mock_schedule(
+        {
+            "id": "sched-123",
+            "tenant": "tenant-1",
+            "org_unit_id": "ou-456",
+            "test_type": "latency",
+            "target": "example.com",
+            "interval_seconds": 300,
+            "enabled": True,
+            "created_at": now,
+            "updated_at": now,
+        }
+    )
+    updated = make_mock_schedule(
+        {
+            "id": "sched-123",
+            "tenant": "tenant-1",
+            "org_unit_id": "ou-456",
+            "test_type": "latency",
+            "target": "example.com",
+            "interval_seconds": 600,  # Changed
+            "enabled": False,  # Changed
+            "created_at": now,
+            "updated_at": now,
+        }
+    )
+
+    db.test_schedules.select = MagicMock(side_effect=[original, updated])
+    db.test_schedules.update = MagicMock()
+
+    manager = ScheduleManager(db, "tenant-1")
+    await manager.initialize()
+
+    result = await manager.update_schedule(
+        "sched-123",
+        {"interval_seconds": 600, "enabled": False},
+    )
+
+    assert result is not None
+    assert result.interval_seconds == 600
+    assert result.enabled is False
+
+    # Verify tenant scoping on update
+    db.test_schedules.update.assert_called_once()
+    call_kwargs = db.test_schedules.update.call_args[1]
+    assert call_kwargs["tenant"] == "tenant-1"
+    assert call_kwargs["id"] == "sched-123"
+
+
+@pytest.mark.asyncio
+async def test_schedule_manager_update_schedule_not_found() -> None:
+    """Test updating a non-existent schedule."""
+    db = MagicMock()
+    db.test_schedules.select = MagicMock(return_value=None)
+
+    manager = ScheduleManager(db, "tenant-1")
+    await manager.initialize()
+
+    result = await manager.update_schedule("nonexistent", {"enabled": False})
+
+    assert result is None
+    db.test_schedules.update.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_schedule_manager_delete_schedule() -> None:
+    """Test deleting a schedule."""
+    db = MagicMock()
+    now = datetime.now(timezone.utc)
+    mock_schedule = make_mock_schedule(
+        {
+            "id": "sched-123",
+            "tenant": "tenant-1",
+            "org_unit_id": "ou-456",
+            "test_type": "latency",
+            "target": "example.com",
+            "interval_seconds": 300,
+            "enabled": True,
+            "created_at": now,
+            "updated_at": now,
+        }
+    )
+    db.test_schedules.select = MagicMock(return_value=mock_schedule)
+    db.test_schedules.delete = MagicMock()
+
+    manager = ScheduleManager(db, "tenant-1")
+    await manager.initialize()
+
+    result = await manager.delete_schedule("sched-123")
+
+    assert result is True
+
+    # Verify tenant scoping
+    db.test_schedules.delete.assert_called_once_with(
+        id="sched-123", tenant="tenant-1"
+    )
+
+
+@pytest.mark.asyncio
+async def test_schedule_manager_delete_schedule_not_found() -> None:
+    """Test deleting a non-existent schedule."""
+    db = MagicMock()
+    db.test_schedules.select = MagicMock(return_value=None)
+
+    manager = ScheduleManager(db, "tenant-1")
+    await manager.initialize()
+
+    result = await manager.delete_schedule("nonexistent")
+
+    assert result is False
+    db.test_schedules.delete.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_schedule_manager_resolve_for_device_ou_specific() -> None:
+    """Test resolving schedules for a device with OU-specific schedules."""
+    db = MagicMock()
+    now = datetime.now(timezone.utc)
+
+    # OU-specific schedules
+    ou_schedules = [
+        make_mock_schedule(
+            {
+                "id": "sched-1",
+                "tenant": "tenant-1",
+                "org_unit_id": "ou-456",
+                "test_type": "latency",
+                "target": "example.com",
+                "interval_seconds": 300,
+                "enabled": True,
+                "created_at": now,
+                "updated_at": now,
+            }
+        ),
+    ]
+
+    # Tenant-wide schedules
+    tenant_wide = [
+        make_mock_schedule(
+            {
+                "id": "sched-2",
+                "tenant": "tenant-1",
+                "org_unit_id": None,
+                "test_type": "throughput",
+                "target": "example.com",
+                "interval_seconds": 600,
+                "enabled": True,
+                "created_at": now,
+                "updated_at": now,
+            }
+        ),
+    ]
+
+    db.test_schedules.select_list = MagicMock(side_effect=[ou_schedules, tenant_wide])
+
+    manager = ScheduleManager(db, "tenant-1")
+    await manager.initialize()
+
+    # Create mock device
+    device = MagicMock()
+    device.id = "device-1"
+    device.org_unit_id = "ou-456"
+
+    result = await manager.resolve_for_device(device)
+
+    assert len(result) == 2
+    assert result[0].id == "sched-1"
+    assert result[0].org_unit_id == "ou-456"
+    assert result[1].id == "sched-2"
+    assert result[1].org_unit_id is None
+
+    # Verify both queries were tenant-scoped and enabled
+    calls = db.test_schedules.select_list.call_args_list
+    assert len(calls) == 2
+
+    # First call: OU-specific
+    assert calls[0][1]["tenant"] == "tenant-1"
+    assert calls[0][1]["org_unit_id"] == "ou-456"
+    assert calls[0][1]["enabled"] is True
+
+    # Second call: tenant-wide
+    assert calls[1][1]["tenant"] == "tenant-1"
+    assert calls[1][1]["org_unit_id"] is None
+    assert calls[1][1]["enabled"] is True
+
+
+@pytest.mark.asyncio
+async def test_schedule_manager_resolve_for_device_excludes_disabled() -> None:
+    """Test that resolve_for_device excludes disabled schedules."""
+    db = MagicMock()
+    now = datetime.now(timezone.utc)
+
+    # Only returns enabled schedules
+    db.test_schedules.select_list = MagicMock(return_value=[])
+
+    manager = ScheduleManager(db, "tenant-1")
+    await manager.initialize()
+
+    device = MagicMock()
+    device.id = "device-1"
+    device.org_unit_id = "ou-456"
+
+    result = await manager.resolve_for_device(device)
+
+    assert len(result) == 0
+
+    # Verify enabled=True was passed
+    calls = db.test_schedules.select_list.call_args_list
+    for call in calls:
+        assert call[1]["enabled"] is True
+
+
+@pytest.mark.asyncio
+async def test_schedule_manager_tenant_isolation() -> None:
+    """Test that schedules from different tenants are isolated."""
+    db = MagicMock()
+    now = datetime.now(timezone.utc)
+
+    # Manager for tenant-1
+    db.test_schedules.select = MagicMock(return_value=None)
+    manager1 = ScheduleManager(db, "tenant-1")
+    await manager1.initialize()
+
+    # Try to get schedule
+    result = await manager1.get_schedule("sched-123")
+
+    assert result is None
+
+    # Verify tenant-1 was used
+    call_kwargs = db.test_schedules.select.call_args[1]
+    assert call_kwargs["tenant"] == "tenant-1"
+
+    # Reset mock
+    db.test_schedules.select.reset_mock()
+
+    # Manager for tenant-2
+    manager2 = ScheduleManager(db, "tenant-2")
+    await manager2.initialize()
+
+    # Try to get schedule
+    result = await manager2.get_schedule("sched-123")
+
+    assert result is None
+
+    # Verify tenant-2 was used (different from tenant-1)
+    call_kwargs = db.test_schedules.select.call_args[1]
+    assert call_kwargs["tenant"] == "tenant-2"

--- a/core/tests/test_wpcl_schedules.py
+++ b/core/tests/test_wpcl_schedules.py
@@ -1,0 +1,426 @@
+"""Tests for WaddlePerf client schedules API endpoints."""
+from __future__ import annotations
+
+import pytest
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, MagicMock, patch
+from quart import Quart
+from typing import Any
+
+from core.modules.waddleperf_client.services.schedule_manager import TestScheduleDTO
+
+
+def make_mock_schedule(
+    schedule_id: str = "test-sched-1",
+    tenant: str = "test-tenant",
+    test_type: str = "ping",
+    target: str = "example.com",
+    interval_seconds: int = 60,
+    org_unit_id: str | None = None,
+    enabled: bool = True,
+) -> TestScheduleDTO:
+    """Create a mock TestScheduleDTO."""
+    return TestScheduleDTO(
+        id=schedule_id,
+        tenant=tenant,
+        org_unit_id=org_unit_id,
+        test_type=test_type,
+        target=target,
+        interval_seconds=interval_seconds,
+        enabled=enabled,
+        created_at=datetime.now(timezone.utc),
+        updated_at=datetime.now(timezone.utc),
+    )
+
+
+# Use fixtures from conftest: app_with_wpc, wpc_write_token, wpc_readonly_token
+
+
+@pytest.mark.asyncio
+async def test_create_schedule_success(
+    app_with_wpc: Quart, wpc_write_token: str
+) -> None:
+    """Test successful schedule creation.
+
+    Args:
+        app_with_wpc: Test app with WPC module.
+        wpc_write_token: Valid JWT token with write scope.
+    """
+    client = app_with_wpc.test_client()
+
+    with patch(
+        "core.modules.waddleperf_client.api.schedules.ScheduleManager"
+    ) as mock_manager_class:
+        mock_mgr = AsyncMock()
+        mock_manager_class.return_value = mock_mgr
+        mock_mgr.initialize = AsyncMock()
+
+        schedule = make_mock_schedule(
+            schedule_id="sched-123",
+            test_type="ping",
+            target="10.0.0.1",
+            interval_seconds=30,
+        )
+        mock_mgr.create_schedule = AsyncMock(return_value=schedule)
+
+        response = await client.post(
+            "/api/v1/waddleperf_client/schedules",
+            json={
+                "test_type": "ping",
+                "target": "10.0.0.1",
+                "interval_seconds": 30,
+            },
+            headers={"Authorization": f"Bearer {wpc_write_token}"},
+        )
+
+        assert response.status_code == 201
+        data = await response.get_json()
+        assert data["id"] == "sched-123"
+        assert data["test_type"] == "ping"
+        assert data["target"] == "10.0.0.1"
+        assert data["interval_seconds"] == 30
+        assert data["enabled"] is True
+        assert data["tenant"] == "test-tenant"
+        assert "meta" in data
+        assert data["meta"]["version"] == 1
+
+
+@pytest.mark.asyncio
+async def test_create_schedule_missing_fields(
+    app_with_wpc: Quart, wpc_write_token: str
+) -> None:
+    """Test schedule creation fails without required fields.
+
+    Args:
+        app_with_wpc: Test app with WPC module.
+        wpc_write_token: Valid JWT token with write scope.
+    """
+    client = app_with_wpc.test_client()
+
+    response = await client.post(
+        "/api/v1/waddleperf_client/schedules",
+        json={"test_type": "ping"},
+        headers={"Authorization": f"Bearer {wpc_write_token}"},
+    )
+
+    assert response.status_code == 400
+    data = await response.get_json()
+    assert "Missing required fields" in data["error"]
+
+
+@pytest.mark.asyncio
+async def test_create_schedule_requires_write_scope(
+    app_with_wpc: Quart, wpc_readonly_token: str
+) -> None:
+    """Test schedule creation fails without write scope.
+
+    Args:
+        app_with_wpc: Test app with WPC module.
+        wpc_readonly_token: Token with read-only scope.
+    """
+    client = app_with_wpc.test_client()
+
+    response = await client.post(
+        "/api/v1/waddleperf_client/schedules",
+        json={
+            "test_type": "ping",
+            "target": "10.0.0.1",
+            "interval_seconds": 30,
+        },
+        headers={"Authorization": f"Bearer {wpc_readonly_token}"},
+    )
+
+    assert response.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_list_schedules_success(
+    app_with_wpc: Quart, wpc_readonly_token: str
+) -> None:
+    """Test successful schedule listing.
+
+    Args:
+        app_with_wpc: Test app with WPC module.
+        wpc_readonly_token: Valid JWT token with read scope.
+    """
+    client = app_with_wpc.test_client()
+
+    with patch(
+        "core.modules.waddleperf_client.api.schedules.ScheduleManager"
+    ) as mock_manager_class:
+        mock_mgr = AsyncMock()
+        mock_manager_class.return_value = mock_mgr
+        mock_mgr.initialize = AsyncMock()
+
+        schedules = [
+            make_mock_schedule(schedule_id="sched-1", test_type="ping"),
+            make_mock_schedule(schedule_id="sched-2", test_type="iperf"),
+        ]
+        mock_mgr.list_schedules = AsyncMock(return_value=schedules)
+
+        response = await client.get(
+            "/api/v1/waddleperf_client/schedules",
+            headers={"Authorization": f"Bearer {wpc_readonly_token}"},
+        )
+
+        assert response.status_code == 200
+        data = await response.get_json()
+        assert len(data["schedules"]) == 2
+        assert data["schedules"][0]["id"] == "sched-1"
+        assert data["schedules"][1]["id"] == "sched-2"
+        assert "meta" in data
+
+
+@pytest.mark.asyncio
+async def test_list_schedules_with_filter(
+    app_with_wpc: Quart, wpc_readonly_token: str
+) -> None:
+    """Test schedule listing with org_unit_id filter.
+
+    Args:
+        app_with_wpc: Test app with WPC module.
+        wpc_readonly_token: Valid JWT token with read scope.
+    """
+    client = app_with_wpc.test_client()
+
+    with patch(
+        "core.modules.waddleperf_client.api.schedules.ScheduleManager"
+    ) as mock_manager_class:
+        mock_mgr = AsyncMock()
+        mock_manager_class.return_value = mock_mgr
+        mock_mgr.initialize = AsyncMock()
+
+        schedules = [
+            make_mock_schedule(schedule_id="sched-1", org_unit_id="ou-1"),
+        ]
+        mock_mgr.list_schedules = AsyncMock(return_value=schedules)
+
+        response = await client.get(
+            "/api/v1/waddleperf_client/schedules?org_unit_id=ou-1",
+            headers={"Authorization": f"Bearer {wpc_readonly_token}"},
+        )
+
+        assert response.status_code == 200
+        data = await response.get_json()
+        assert len(data["schedules"]) == 1
+        assert data["schedules"][0]["org_unit_id"] == "ou-1"
+
+        # Verify the manager was called with the filter
+        mock_mgr.list_schedules.assert_called_once_with(org_unit_id="ou-1")
+
+
+@pytest.mark.asyncio
+async def test_get_schedule_success(
+    app_with_wpc: Quart, wpc_readonly_token: str
+) -> None:
+    """Test successful schedule retrieval.
+
+    Args:
+        app_with_wpc: Test app with WPC module.
+        wpc_readonly_token: Valid JWT token with read scope.
+    """
+    client = app_with_wpc.test_client()
+
+    with patch(
+        "core.modules.waddleperf_client.api.schedules.ScheduleManager"
+    ) as mock_manager_class:
+        mock_mgr = AsyncMock()
+        mock_manager_class.return_value = mock_mgr
+        mock_mgr.initialize = AsyncMock()
+
+        schedule = make_mock_schedule(schedule_id="sched-456")
+        mock_mgr.get_schedule = AsyncMock(return_value=schedule)
+
+        response = await client.get(
+            "/api/v1/waddleperf_client/schedules/sched-456",
+            headers={"Authorization": f"Bearer {wpc_readonly_token}"},
+        )
+
+        assert response.status_code == 200
+        data = await response.get_json()
+        assert data["id"] == "sched-456"
+        assert "meta" in data
+
+
+@pytest.mark.asyncio
+async def test_get_schedule_not_found(
+    app_with_wpc: Quart, wpc_readonly_token: str
+) -> None:
+    """Test schedule retrieval when not found.
+
+    Args:
+        app_with_wpc: Test app with WPC module.
+        wpc_readonly_token: Valid JWT token with read scope.
+    """
+    client = app_with_wpc.test_client()
+
+    with patch(
+        "core.modules.waddleperf_client.api.schedules.ScheduleManager"
+    ) as mock_manager_class:
+        mock_mgr = AsyncMock()
+        mock_manager_class.return_value = mock_mgr
+        mock_mgr.initialize = AsyncMock()
+        mock_mgr.get_schedule = AsyncMock(return_value=None)
+
+        response = await client.get(
+            "/api/v1/waddleperf_client/schedules/nonexistent",
+            headers={"Authorization": f"Bearer {wpc_readonly_token}"},
+        )
+
+        assert response.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_update_schedule_success(
+    app_with_wpc: Quart, wpc_write_token: str
+) -> None:
+    """Test successful schedule update.
+
+    Args:
+        app_with_wpc: Test app with WPC module.
+        wpc_write_token: Valid JWT token with write scope.
+    """
+    client = app_with_wpc.test_client()
+
+    with patch(
+        "core.modules.waddleperf_client.api.schedules.ScheduleManager"
+    ) as mock_manager_class:
+        mock_mgr = AsyncMock()
+        mock_manager_class.return_value = mock_mgr
+        mock_mgr.initialize = AsyncMock()
+
+        updated_schedule = make_mock_schedule(
+            schedule_id="sched-789",
+            interval_seconds=120,
+        )
+        mock_mgr.update_schedule = AsyncMock(return_value=updated_schedule)
+
+        response = await client.put(
+            "/api/v1/waddleperf_client/schedules/sched-789",
+            json={"interval_seconds": 120},
+            headers={"Authorization": f"Bearer {wpc_write_token}"},
+        )
+
+        assert response.status_code == 200
+        data = await response.get_json()
+        assert data["id"] == "sched-789"
+        assert data["interval_seconds"] == 120
+
+
+@pytest.mark.asyncio
+async def test_delete_schedule_success(
+    app_with_wpc: Quart, wpc_write_token: str
+) -> None:
+    """Test successful schedule deletion.
+
+    Args:
+        app_with_wpc: Test app with WPC module.
+        wpc_write_token: Valid JWT token with write scope.
+    """
+    client = app_with_wpc.test_client()
+
+    with patch(
+        "core.modules.waddleperf_client.api.schedules.ScheduleManager"
+    ) as mock_manager_class:
+        mock_mgr = AsyncMock()
+        mock_manager_class.return_value = mock_mgr
+        mock_mgr.initialize = AsyncMock()
+        mock_mgr.delete_schedule = AsyncMock(return_value=True)
+
+        response = await client.delete(
+            "/api/v1/waddleperf_client/schedules/sched-999",
+            headers={"Authorization": f"Bearer {wpc_write_token}"},
+        )
+
+        assert response.status_code == 200
+        data = await response.get_json()
+        assert "deleted successfully" in data["message"]
+
+
+@pytest.mark.asyncio
+async def test_delete_schedule_not_found(
+    app_with_wpc: Quart, wpc_write_token: str
+) -> None:
+    """Test schedule deletion when not found.
+
+    Args:
+        app_with_wpc: Test app with WPC module.
+        wpc_write_token: Valid JWT token with write scope.
+    """
+    client = app_with_wpc.test_client()
+
+    with patch(
+        "core.modules.waddleperf_client.api.schedules.ScheduleManager"
+    ) as mock_manager_class:
+        mock_mgr = AsyncMock()
+        mock_manager_class.return_value = mock_mgr
+        mock_mgr.initialize = AsyncMock()
+        mock_mgr.delete_schedule = AsyncMock(return_value=False)
+
+        response = await client.delete(
+            "/api/v1/waddleperf_client/schedules/nonexistent",
+            headers={"Authorization": f"Bearer {wpc_write_token}"},
+        )
+
+        assert response.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_schedules_tenant_isolation(
+    app_with_wpc: Quart, wpc_write_token: str
+) -> None:
+    """Test that schedules are scoped to tenant claim.
+
+    Args:
+        app_with_wpc: Test app with WPC module.
+        wpc_write_token: Valid JWT token with write scope.
+    """
+    client = app_with_wpc.test_client()
+
+    with patch(
+        "core.modules.waddleperf_client.api.schedules.ScheduleManager"
+    ) as mock_manager_class:
+        mock_mgr = AsyncMock()
+        mock_manager_class.return_value = mock_mgr
+        mock_mgr.initialize = AsyncMock()
+
+        schedule = make_mock_schedule(schedule_id="sched-123")
+        mock_mgr.create_schedule = AsyncMock(return_value=schedule)
+
+        response = await client.post(
+            "/api/v1/waddleperf_client/schedules",
+            json={
+                "test_type": "ping",
+                "target": "10.0.0.1",
+                "interval_seconds": 30,
+            },
+            headers={"Authorization": f"Bearer {wpc_write_token}"},
+        )
+
+        assert response.status_code == 201
+
+        # Verify ScheduleManager was instantiated with test-tenant
+        # Check that the second argument is "test-tenant"
+        call_args = mock_manager_class.call_args
+        assert call_args[0][1] == "test-tenant"
+
+
+@pytest.mark.asyncio
+async def test_create_schedule_missing_auth(app_with_wpc: Quart) -> None:
+    """Test schedule creation without authorization.
+
+    Args:
+        app_with_wpc: Test app with WPC module.
+    """
+    client = app_with_wpc.test_client()
+
+    response = await client.post(
+        "/api/v1/waddleperf_client/schedules",
+        json={
+            "test_type": "ping",
+            "target": "10.0.0.1",
+            "interval_seconds": 30,
+        },
+    )
+
+    assert response.status_code == 403

--- a/core/tests/test_wpcl_version.py
+++ b/core/tests/test_wpcl_version.py
@@ -1,0 +1,226 @@
+"""Tests for WaddlePerf client version API endpoint."""
+from __future__ import annotations
+
+import pytest
+from datetime import datetime, timezone
+from unittest.mock import patch
+from quart import Quart
+from typing import Any
+
+
+# Use fixtures from conftest: app_with_wpc, wpc_readonly_token
+
+
+@pytest.mark.asyncio
+async def test_get_version_success(app_with_wpc: Quart, wpc_readonly_token: str) -> None:
+    """Test successful version retrieval.
+
+    Args:
+        app_with_wpc: Test app with WPC module.
+        wpc_readonly_token: Valid JWT token with read scope.
+    """
+    client = app_with_wpc.test_client()
+
+    response = await client.get(
+        "/api/v1/waddleperf_client/version",
+        headers={"Authorization": f"Bearer {wpc_readonly_token}"},
+    )
+
+    assert response.status_code == 200
+    data = await response.get_json()
+    assert "latest_version" in data
+    assert "min_version" in data
+    assert "download_url" in data
+    assert "meta" in data
+    assert data["meta"]["version"] == 1
+
+
+@pytest.mark.asyncio
+async def test_get_version_returns_configured_values(
+    app_with_wpc: Quart, wpc_readonly_token: str
+) -> None:
+    """Test that version endpoint returns configured values.
+
+    Args:
+        app_with_wpc: Test app with WPC module.
+        wpc_readonly_token: Valid JWT token with read scope.
+    """
+    client = app_with_wpc.test_client()
+
+    # Set configured values
+    app_with_wpc.config["WPCL_LATEST_VERSION"] = "2.1.0"
+    app_with_wpc.config["WPCL_MIN_VERSION"] = "1.5.0"
+    app_with_wpc.config["WPCL_DOWNLOAD_URL"] = "https://custom-download.com/wpcl"
+
+    response = await client.get(
+        "/api/v1/waddleperf_client/version",
+        headers={"Authorization": f"Bearer {wpc_readonly_token}"},
+    )
+
+    assert response.status_code == 200
+    data = await response.get_json()
+    assert data["latest_version"] == "2.1.0"
+    assert data["min_version"] == "1.5.0"
+    assert data["download_url"] == "https://custom-download.com/wpcl"
+
+
+@pytest.mark.asyncio
+async def test_get_version_default_values(
+    app_with_wpc: Quart, wpc_readonly_token: str
+) -> None:
+    """Test that version endpoint returns sensible defaults.
+
+    Args:
+        app_with_wpc: Test app with WPC module.
+        wpc_readonly_token: Valid JWT token with read scope.
+    """
+    client = app_with_wpc.test_client()
+
+    # Ensure config values are not set
+    app_with_wpc.config.pop("WPCL_LATEST_VERSION", None)
+    app_with_wpc.config.pop("WPCL_MIN_VERSION", None)
+    app_with_wpc.config.pop("WPCL_DOWNLOAD_URL", None)
+
+    response = await client.get(
+        "/api/v1/waddleperf_client/version",
+        headers={"Authorization": f"Bearer {wpc_readonly_token}"},
+    )
+
+    assert response.status_code == 200
+    data = await response.get_json()
+    assert data["latest_version"] == "1.0.0"
+    assert data["min_version"] == "0.1.0"
+    assert "downloads.tobogganing.app" in data["download_url"]
+
+
+@pytest.mark.asyncio
+async def test_get_version_requires_tenant(app_with_wpc: Quart) -> None:
+    """Test that version endpoint requires tenant claim.
+
+    Args:
+        app_with_wpc: Test app with WPC module.
+    """
+    client = app_with_wpc.test_client()
+
+    response = await client.get("/api/v1/waddleperf_client/version")
+
+    assert response.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_get_version_requires_valid_token(app_with_wpc: Quart) -> None:
+    """Test that version endpoint requires valid JWT token.
+
+    Args:
+        app_with_wpc: Test app with WPC module.
+    """
+    client = app_with_wpc.test_client()
+
+    response = await client.get(
+        "/api/v1/waddleperf_client/version",
+        headers={"Authorization": "Bearer invalid-token"},
+    )
+
+    assert response.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_get_version_meta_timestamp(
+    app_with_wpc: Quart, wpc_readonly_token: str
+) -> None:
+    """Test that version response includes meta with timestamp.
+
+    Args:
+        app_with_wpc: Test app with WPC module.
+        wpc_readonly_token: Valid JWT token with read scope.
+    """
+    client = app_with_wpc.test_client()
+
+    response = await client.get(
+        "/api/v1/waddleperf_client/version",
+        headers={"Authorization": f"Bearer {wpc_readonly_token}"},
+    )
+
+    assert response.status_code == 200
+    data = await response.get_json()
+    assert "meta" in data
+    assert data["meta"]["version"] == 1
+    assert "timestamp" in data["meta"]
+
+    # Verify timestamp is valid ISO format
+    timestamp_str = data["meta"]["timestamp"]
+    # This should not raise
+    datetime.fromisoformat(timestamp_str.replace("Z", "+00:00"))
+
+
+@pytest.mark.asyncio
+async def test_get_version_is_flag_gated(
+    app_with_wpc: Quart, wpc_readonly_token: str
+) -> None:
+    """Test that version endpoint is gated behind feature flag.
+
+    Args:
+        app_with_wpc: Test app with WPC module.
+        wpc_readonly_token: Valid JWT token with read scope.
+    """
+    client = app_with_wpc.test_client()
+
+    with patch(
+        "core.modules.waddleperf_client.api.version.require_feature"
+    ) as mock_require_feature:
+        # Mock the decorator to ensure it's applied
+        def mock_decorator(module: str, feature: str):
+            def decorator(func):
+                # Still call the function, but verify it was decorated
+                return func
+            return decorator
+
+        mock_require_feature.side_effect = mock_decorator
+
+        response = await client.get(
+            "/api/v1/waddleperf_client/version",
+            headers={"Authorization": f"Bearer {wpc_readonly_token}"},
+        )
+
+        # Should succeed because the mock doesn't actually gate
+        assert response.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_get_version_no_write_scope_required(
+    app_with_wpc: Quart, wpc_readonly_token: str
+) -> None:
+    """Test that version endpoint does not require write scope.
+
+    Args:
+        app_with_wpc: Test app with WPC module.
+        wpc_readonly_token: Token with read-only scope.
+    """
+    client = app_with_wpc.test_client()
+
+    response = await client.get(
+        "/api/v1/waddleperf_client/version",
+        headers={"Authorization": f"Bearer {wpc_readonly_token}"},
+    )
+
+    # Should succeed with read-only token (no specific scope required beyond tenant)
+    assert response.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_get_version_malformed_auth_header(
+    app_with_wpc: Quart,
+) -> None:
+    """Test version retrieval with malformed Authorization header.
+
+    Args:
+        app_with_wpc: Test app with WPC module.
+    """
+    client = app_with_wpc.test_client()
+
+    response = await client.get(
+        "/api/v1/waddleperf_client/version",
+        headers={"Authorization": "NotBearer token123"},
+    )
+
+    assert response.status_code == 403

--- a/docs/superpowers/plans/2026-07-09-phase-3b-waddleperf-client.md
+++ b/docs/superpowers/plans/2026-07-09-phase-3b-waddleperf-client.md
@@ -1,0 +1,65 @@
+# Phase 3b — WaddlePerf Client Module (thin) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: superpowers:subagent-driven-development or superpowers:executing-plans. Steps use `- [ ]` checkboxes.
+
+**Goal:** Add the small `waddleperf_client` module — the genuinely-distinct client-facing surface not already covered by `waddleperf_cluster`: test **schedule/config distribution** to devices and a **client version/update-check** endpoint.
+
+**Architecture:** A thin Quart module at `/api/v1/waddleperf_client`. Devices (authenticated by their per-device API key, via the shared global-lookup helper from 3a) pull their assigned test schedule + config; admins manage schedules per org-unit; a public/tenant version endpoint reports the latest client version for in-app update checks. Stacked on Phase 3a.
+
+**Tech Stack:** Quart, penguin-dal (runtime), SQLAlchemy+Alembic (schema), PostHog flags + entitlements, pytest.
+
+## Global Constraints
+- Python 3.13; type hints; `@dataclass(slots=True)`; no bare except; `python3`; every file <1000 lines.
+- Runtime DB via tenant-scoped penguin-dal; schema via Alembic only. Single `users` table; tenant column on every table; UUID refs.
+- Every feature behind `tobogganing.waddleperf_client.{feature}` flag (default OFF) via `@require_feature`. All features **community** tier (basic client management is free).
+- Device auth reuses `core/modules/waddleperf_cluster/services/device_auth.authenticate_device_global` (global api_key_hash lookup → device+tenant). Never trust tenant/device from body/header.
+- Module mounts at `/api/v1/waddleperf_client` (registry combines module prefix + each blueprint's `url_prefix`). Register in module autodiscovery like `waddleperf_cluster`.
+
+## File Structure
+```
+core/modules/waddleperf_client/
+  __init__.py                       # module() -> ModuleContract
+  api/{schedules,client_config,version}.py
+  services/{schedule_manager.py}
+core/db/models.py                   # + TestSchedule
+core/migrations/versions/0013_wpc_test_schedules.py
+core/tests/test_wpcl_*.py
+```
+
+---
+
+## Task Group A — Schema + manager
+
+### Task A1: TestSchedule model + migration 0013
+**Files:** `core/db/models.py` (+ `TestSchedule`), `core/migrations/versions/0013_wpc_test_schedules.py`, `core/tests/test_migrations_head.py`, `core/tests/test_wpcl_models.py`
+- `TestSchedule` (test_schedules): id, tenant, org_unit_id (nullable → tenant-wide), test_type, target, interval_seconds (int), enabled (bool), created_at, updated_at. Index(tenant, org_unit_id). No `metadata` column; if any JSON, use `Column("metadata", ...)`.
+- Migration 0013 (down_revision "0012") creates `test_schedules`; update `test_migrations_head` expectations; `alembic upgrade head` == Base.metadata.
+- TDD; full suite green.
+
+### Task A2: ScheduleManager
+**Files:** `core/modules/waddleperf_client/services/schedule_manager.py`, `core/tests/test_wpcl_schedule_manager.py`
+- `ScheduleManager(db, tenant)`: `create_schedule`, `list_schedules` (filter org_unit), `update_schedule`, `delete_schedule`, and `resolve_for_device(device)` → the effective enabled schedules for a device's org_unit (org-unit-specific + tenant-wide). Tenant-scoped. Mocked-DAL tests.
+
+## Task Group B — Blueprints + contract
+
+### Task B1: schedules (admin) + client_config (device-facing) blueprints
+**Files:** `core/modules/waddleperf_client/api/schedules.py`, `core/modules/waddleperf_client/api/client_config.py`, tests
+- `schedules.py` — `Blueprint("wpcl_schedules", url_prefix="/schedules")`: `POST ""`, `GET ""`, `GET/PUT/DELETE "/<schedule_id>"` — JWT + `schedules:read`/`:write` + `@require_feature("waddleperf_client","schedules")`, tenant from claims.
+- `client_config.py` — `Blueprint("wpcl_config", url_prefix="/config")`: `GET ""` — **device-facing**: authenticate the device via `authenticate_device_global(get_db(), api_key)` (tenant+device from record), return the resolved schedule + any `client_configs` for the device's org-unit. Flag `@require_feature("waddleperf_client","config")` checked inline (device path, no user JWT). Fail closed on bad key.
+- Tests: admin CRUD + tenant isolation + flag/scope gates; device config-fetch requires a valid device key (bogus→401), returns resolved schedules, tenant from record.
+
+### Task B2: version endpoint + module contract
+**Files:** `core/modules/waddleperf_client/api/version.py`, `core/modules/waddleperf_client/api/__init__.py`, `core/modules/waddleperf_client/__init__.py`, module autodiscovery registration, `core/tests/test_wpcl_contract.py`
+- `version.py` — `Blueprint("wpcl_version", url_prefix="/version")`: `GET ""` returns `{latest_version, min_version, download_url}` from `Config`/env (`WPCL_LATEST_VERSION`, `WPCL_MIN_VERSION`, `WPCL_DOWNLOAD_URL`) — no DB. `@require_feature("waddleperf_client","version")`; `@require_tenant` (or public if the version check must be pre-auth — default tenant-gated, document). Include `meta`.
+- `api/__init__.py`: export `blueprints=[schedules, client_config, version]`.
+- `__init__.py` `module()`: name `waddleperf_client`; blueprints; flags `tobogganing.waddleperf_client.{schedules,config,version}`; entitlements all community; nav (Schedules); migrations `["0013"]`; health None. Register in autodiscovery like `waddleperf_cluster`.
+- `test_wpcl_contract.py`: create_app URL-map asserts routes at `/api/v1/waddleperf_client/{schedules,config,version}`; flags default OFF; other modules unchanged.
+
+## Task Group C — Verify + PR
+- Full `core/` suite green; every file <1000; `alembic upgrade head` == Base.metadata (0001→0013); mypy strict on module.
+- PR `feature/phase-3b-waddleperf-client` → base `feature/phase-3a-waddleperf-cluster` (stacked); note it completes Phase 3.
+
+## Self-Review Notes
+- Reuse `device_auth.authenticate_device_global` — do NOT reintroduce tenant-from-header/body.
+- JSON columns → `Column("metadata", ...)` (reserved-attr rule).
+- Orchestrator runs the FULL suite at each checkpoint; fix agents edit-and-test only on disjoint files; orchestrator owns shared `__init__`/contract wiring.


### PR DESCRIPTION
## Phase 3b — WaddlePerf **client** module (thin)

Adds the small `waddleperf_client` module — the client-facing surface not already covered by `waddleperf_cluster` (which shipped enroll/results/live-test in 3a). **Completes Phase 3.** Stacked on Phase 3a (#56) — review against that base.

### Module (`/api/v1/waddleperf_client`)
- **schedules** — admin CRUD for per-org-unit (or tenant-wide) test schedules (JWT + scope).
- **config** — device-facing `GET /config`: authenticates the device by its API key (global `api_key_hash` lookup → device+tenant, no header trust) and returns the resolved schedules + client config for the device's org-unit.
- **version** — `GET /version` for in-app client update checks (latest/min version + download URL from config/env).

Full `ModuleContract`: 3 flags (`tobogganing.waddleperf_client.*`, default OFF), all **community** tier, nav, migration 0013; registered in `core.modules.__all__` autodiscovery.

### Schema
- Alembic **0013** — `test_schedules` (tenant-scoped; org-unit-specific or tenant-wide). `alembic upgrade head` = all model tables (0001→0013).

### Design
- Honors the "each aspect is its own module" intent while staying thin — most client server-side needs (enroll, result upload, live-test) already live in `waddleperf_cluster`.
- Device auth reuses the 3a shared `authenticate_device_global` helper — tenant derived from the device record, never a header/body.

### Tests
563 passing (+1 skipped: the WS-rejection unit test, a documented Quart test-client limitation carried from 3a); every file < 1000 lines; migration chain verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Introduce the WaddlePerf client module providing tenant-scoped schedules, device-facing config distribution, and version metadata, backed by a new test_schedules table and migration.

New Features:
- Add waddleperf_client module with schedules, client config, and version API surfaces mounted under /api/v1/waddleperf_client.
- Provide admin JWT-based CRUD APIs for test schedules, scoped per tenant and org unit.
- Expose a device-authenticated config endpoint that returns resolved schedules and client configuration for the device’s org unit.
- Expose a feature-gated version endpoint that reports latest/min client versions and download URL from configuration.

Enhancements:
- Extend core DB schema and Alembic migrations with a tenant-scoped test_schedules table and ensure migration coverage tests include it.
- Integrate waddleperf_client into module autodiscovery, feature flags, entitlements, and navigation alongside existing modules.

Tests:
- Add unit and integration tests for the TestSchedule model, schedule manager, schedules/config/version endpoints, and module contract wiring, including tenant scoping and flag behavior.
- Update migration head tests and test app fixtures to cover the new module, schema, flags, and JWT scopes.