### PR TITLE
[Chore] Add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,11 @@
+# Code owners for penguintechinc/tobogganing
+#
+# The org default-branch ruleset sets require_code_owner_review, so every PR
+# into the default branch needs an approving review from someone listed here.
+#
+# Two owners deliberately. GitHub forbids approving your own PR, so a single
+# owner who also writes most of the PRs would make every one of them
+# unmergeable except by admin bypass — which would defeat the review
+# requirement rather than satisfy it.
+
+*   @PenguinzTech @Chromeninja


### PR DESCRIPTION
## Summary

The org default-branch ruleset sets `require_code_owner_review`, so every PR into `main` requires an approving review from a code owner. This repo has no CODEOWNERS file, so that requirement currently matches nobody — making every PR unmergeable without an admin bypass.

This adds `.github/CODEOWNERS` with:

```
*   @PenguinzTech @Chromeninja
```

Two owners deliberately: GitHub forbids approving your own PR, so a single owner who also authors most PRs would make every one of them unmergeable except by admin bypass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Chores:
- Introduce a .github/CODEOWNERS file assigning all paths to the designated code owners.