### PR TITLE
[Feature] Wire usage metering reporter (seat/node keepalive)

### DIFF
--- a/hub_api/app.py
+++ b/hub_api/app.py
@@ -138,6 +138,52 @@ def create_app(config: Config | None = None) -> Quart:
                 logger.error(f"Failed to initialize encryptor: {e}")
                 raise
 
+            # Initialize usage reporter for license keepalive
+            try:
+                from hub_api.entitlements.metering import (
+                    UsageReporter,
+                    count_registered_nodes,
+                )
+                from shared.licensing.python_client import get_client
+
+                license_client = get_client()
+                if license_client is not None:
+                    # Create reporter with real node counter
+                    reporter = UsageReporter(
+                        db=db,
+                        license_client=license_client,
+                        node_counter=lambda: count_registered_nodes(db),
+                    )
+                    app.usage_reporter = reporter  # type: ignore[attr-defined]
+
+                    # Schedule hourly keepalive task
+                    async def hourly_keepalive() -> None:
+                        """Send usage report to license server hourly (best-effort)."""
+                        while True:
+                            try:
+                                await asyncio.sleep(3600)  # 1 hour
+                                success = await reporter.report()
+                                if not success:
+                                    logger.warning(
+                                        "Usage report failed (will retry in 1h)"
+                                    )
+                            except asyncio.CancelledError:
+                                logger.info("Hourly keepalive task cancelled")
+                                break
+                            except Exception as e:
+                                logger.error(f"Unexpected error in keepalive task: {e}")
+
+                    # Start the keepalive task in background (never await it here)
+                    app.keepalive_task = asyncio.create_task(hourly_keepalive())  # type: ignore[attr-defined]
+                    logger.info("Usage reporter initialized with hourly keepalive")
+                else:
+                    logger.warning(
+                        "License client not available; usage reporting disabled"
+                    )
+            except Exception as e:
+                logger.error(f"Failed to initialize usage reporter: {e}")
+                # Non-fatal; continue startup
+
             logger.info("Services initialized on app startup")
 
     # Liveness probe endpoint (lightweight, no dependencies)

--- a/hub_api/entitlements/metering.py
+++ b/hub_api/entitlements/metering.py
@@ -1,10 +1,11 @@
 """Usage metering for license reporting."""
+
 from __future__ import annotations
 
 import asyncio
 import logging
 from dataclasses import dataclass
-from typing import Callable, Optional
+from typing import Any, Callable, Optional
 
 logger = logging.getLogger(__name__)
 
@@ -16,6 +17,52 @@ class Usage:
     seats: int  # Distinct active identities (human or machine/AI)
     nodes: int  # Count of registered clusters/headends/testservers
     features: frozenset[str]  # Enabled Enterprise features
+
+
+async def count_active_seats(db: Any) -> int:
+    """Count distinct active identities (seats) from users table.
+
+    Args:
+        db: penguin-dal database connection
+
+    Returns:
+        Number of distinct active identities in the users table.
+    """
+    try:
+        # Query all users (both active and inactive; Phase 3 can add activity filter)
+        def query_users() -> int:
+            try:
+                result = db.users.select()
+                return len(result) if result else 0
+            except Exception as e:
+                logger.error(f"Error in query_users: {e}")
+                return 0
+
+        # Run sync DB query in thread pool to avoid blocking async context
+        count = await asyncio.to_thread(query_users)
+        return count
+    except Exception as e:
+        logger.error(f"Failed to count active seats: {e}")
+        return 0
+
+
+def count_registered_nodes(db: Any) -> int:
+    """Count registered clusters/orchestrators/nodes.
+
+    Args:
+        db: penguin-dal database connection
+
+    Returns:
+        Number of registered cluster/orchestrator nodes.
+    """
+    try:
+        # Query all clusters (registered orchestrators/headends)
+        # TODO(spec §8 #6): confirm node unit definition post-Phase 1
+        result = db.clusters.select()
+        return len(result) if result else 0
+    except Exception as e:
+        logger.error(f"Failed to count registered nodes: {e}")
+        return 0
 
 
 class UsageReporter:
@@ -51,11 +98,7 @@ class UsageReporter:
             # Count distinct active identities (seats) from users table
             seats = 0
             try:
-                # Count total users (both active and inactive for now)
-                # In Phase 1, we count all users; Phase 3 can add activity filter
-                # Use a condition that matches all rows (id != "")
-                result = await self.db(self.db.users.id != "").select()
-                seats = len(result) if result else 0
+                seats = await count_active_seats(self.db)
             except Exception as e:
                 logger.error(f"Failed to count users: {e}")
                 seats = 0
@@ -73,8 +116,8 @@ class UsageReporter:
             try:
                 from quart import current_app
 
-                registry = current_app.registry
-                for entitlement in registry._entitlements:
+                registry = current_app.registry  # type: ignore[attr-defined]
+                for entitlement in registry._entitlements:  # type: ignore[attr-defined]
                     # Only include Enterprise features that are enabled
                     if entitlement.tier.lower() == "enterprise":
                         # Check if the feature is enabled via flags
@@ -135,7 +178,7 @@ class UsageReporter:
                     return False
 
                 try:
-                    self.license_client.keepalive(usage_data)
+                    self.license_client.keepalive(usage_data)  # type: ignore[attr-defined]
                     logger.info(
                         f"Usage reported: seats={usage.seats}, nodes={usage.nodes}, "
                         f"features={len(usage.features)}"

--- a/hub_api/tests/test_metering.py
+++ b/hub_api/tests/test_metering.py
@@ -35,12 +35,10 @@ async def test_usage_snapshot_counts_seats() -> None:
     # Create mock db with fresh setup
     mock_rowset = make_mock_rowset([user1, user2, user3])
 
-    # Setup query proxy with proper async select
-    query_proxy = MockQueryProxy(mock_rowset)
-
-    # Create mock db that returns query_proxy when called
-    mock_db = MagicMock(side_effect=lambda *args, **kwargs: query_proxy)  # noqa: ARG005
+    # Mock db.users.select() to return the rowset
+    mock_db = MagicMock()
     mock_db.users = MagicMock()
+    mock_db.users.select = MagicMock(return_value=mock_rowset)
 
     # Create reporter with patched app context
     license_client = MagicMock()
@@ -63,9 +61,9 @@ async def test_usage_snapshot_empty_users() -> None:
 
     # Mock empty users table
     mock_rowset = make_mock_rowset([])
-    query_proxy = MockQueryProxy(mock_rowset)
-    mock_db = MagicMock(side_effect=lambda *args, **kwargs: query_proxy)  # noqa: ARG005
+    mock_db = MagicMock()
     mock_db.users = MagicMock()
+    mock_db.users.select = MagicMock(return_value=mock_rowset)
 
     license_client = MagicMock()
     reporter = UsageReporter(mock_db, license_client)
@@ -148,9 +146,9 @@ async def test_report_success() -> None:
 
     user1 = MagicMock(id="user1")
     mock_rowset = make_mock_rowset([user1])
-    query_proxy = MockQueryProxy(mock_rowset)
-    mock_db = MagicMock(side_effect=lambda *args, **kwargs: query_proxy)  # noqa: ARG005
+    mock_db = MagicMock()
     mock_db.users = MagicMock()
+    mock_db.users.select = MagicMock(return_value=mock_rowset)
 
     license_client = MagicMock()
     license_client.keepalive = MagicMock()
@@ -217,9 +215,9 @@ async def test_report_caches_snapshot_fallback() -> None:
 
     user1 = MagicMock(id="user1")
     mock_rowset = make_mock_rowset([user1])
-    query_proxy = MockQueryProxy(mock_rowset)
-    mock_db = MagicMock(side_effect=lambda *args, **kwargs: query_proxy)  # noqa: ARG005
+    mock_db = MagicMock()
     mock_db.users = MagicMock()
+    mock_db.users.select = MagicMock(return_value=mock_rowset)
 
     license_client = MagicMock()
     license_client.keepalive = MagicMock()
@@ -234,3 +232,62 @@ async def test_report_caches_snapshot_fallback() -> None:
 
     # Verify cache was stored
     assert reporter._last_snapshot.seats == 1
+
+
+@pytest.mark.asyncio
+async def test_seat_counter_from_users_table() -> None:
+    """Test seat counter queries users table for distinct active identities."""
+    from hub_api.entitlements.metering import count_active_seats
+    from hub_api.tests.conftest import make_mock_rowset
+
+    # Create mock user rows (distinct identities)
+    user1 = MagicMock(id="uuid-1")
+    user2 = MagicMock(id="uuid-2")
+    user3 = MagicMock(id="uuid-3")
+
+    mock_rowset = make_mock_rowset([user1, user2, user3])
+    mock_db = MagicMock()
+    mock_db.users = MagicMock()
+    mock_db.users.select = MagicMock(return_value=mock_rowset)
+
+    # Call the seat counter
+    seats = await count_active_seats(mock_db)
+
+    assert seats == 3
+
+
+@pytest.mark.asyncio
+async def test_node_counter_from_clusters_table() -> None:
+    """Test node counter queries clusters table for registered orchestrators."""
+    from hub_api.entitlements.metering import count_registered_nodes
+    from hub_api.tests.conftest import make_mock_rowset
+
+    # Create mock cluster rows (registered nodes/orchestrators)
+    cluster1 = MagicMock(id="cluster-1", name="hub-1")
+    cluster2 = MagicMock(id="cluster-2", name="hub-2")
+
+    mock_rowset = make_mock_rowset([cluster1, cluster2])
+    mock_db = MagicMock()
+    mock_db.clusters = MagicMock()
+    mock_db.clusters.select = MagicMock(return_value=mock_rowset)
+
+    # Call the node counter (sync version for backward compat with node_counter callable)
+    nodes = count_registered_nodes(mock_db)
+
+    assert nodes == 2
+
+
+@pytest.mark.asyncio
+async def test_node_counter_empty_clusters() -> None:
+    """Test node counter returns 0 when no clusters registered."""
+    from hub_api.entitlements.metering import count_registered_nodes
+    from hub_api.tests.conftest import make_mock_rowset
+
+    mock_rowset = make_mock_rowset([])
+    mock_db = MagicMock()
+    mock_db.clusters = MagicMock()
+    mock_db.clusters.select = MagicMock(return_value=mock_rowset)
+
+    nodes = count_registered_nodes(mock_db)
+
+    assert nodes == 0


### PR DESCRIPTION
Wires the dead `UsageReporter` (`hub_api/entitlements/metering.py`) so per-seat/per-node billing actually reports.

- Seat counter = distinct identities in `users` (all users for now; active-only filter is a billing-accuracy follow-up).
- Node counter = registered clusters (`# TODO spec §8 #6`: confirm node unit).
- `@app.before_serving` spawns an hourly keepalive via `asyncio.create_task` — non-blocking, graceful on failure.
- Tests: 15 passed.

Stacked on `refactor/perftest-module-rename`; rebases to release once #71/#74 land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)