### PR TITLE
feat(hub-api): ziti module scaffold (Phase 5 split)

### DIFF
--- a/hub_api/modules/__init__.py
+++ b/hub_api/modules/__init__.py
@@ -6,4 +6,5 @@ __all__ = [
     "perftest_cluster",
     "perftest_client",
     "perftest_c2c",
+    "ziti",
 ]

--- a/hub_api/modules/ziti/README.md
+++ b/hub_api/modules/ziti/README.md
@@ -1,0 +1,24 @@
+# Ziti Module
+
+**Status:** Greenfield scaffold (implementation pending)
+
+## Overview
+
+The ziti module integrates OpenZiti identity and access control into the Tobogganing hub-api. It provides an alternative or complementary identity provider and transport mechanism alongside or independent of sdwan tunneling.
+
+## Architecture
+
+- **Control-plane integration** (professional tier): OpenZiti controller management and configuration
+- **SDK integration** (enterprise tier): Client-side SDK initialization and policy enforcement
+- **Transport-independent**: No hard dependency on sdwan or any specific tunnel transport; can coexist or serve as an alternative
+
+## Roadmap
+
+- Phase 1: OpenZiti controller API client (authentication, service discovery, identity enrollment)
+- Phase 2: SDK wrapper for client-side identity binding and session management
+- Phase 3: Context-aware policy enforcement (threat intelligence, impossible-travel detection)
+- Phase 4: Integration with audit and compliance logging
+
+## Current State
+
+Currently a placeholder module that mounts cleanly to the registry. Full implementation is deferred pending roadmap phases.

--- a/hub_api/modules/ziti/__init__.py
+++ b/hub_api/modules/ziti/__init__.py
@@ -1,0 +1,32 @@
+"""Ziti module - Identity and access control scaffold for OpenZiti integration."""
+from __future__ import annotations
+
+from hub_api.modules.ziti.api import blueprints
+from hub_api.registry import Entitlement, ModuleContract, NavEntry
+
+
+def module() -> ModuleContract:
+    """Return the module contract for the ziti module.
+
+    Provides OpenZiti control-plane and SDK integration scaffolding, functioning
+    as an alternative identity/transport layer alongside or independent of sdwan.
+
+    Returns:
+        ModuleContract with ziti blueprints, feature flags, entitlements,
+        navigation entries, and migration history.
+    """
+    return ModuleContract(
+        name="ziti",
+        blueprints=list(blueprints),
+        nav=[NavEntry("Identity", "/api/v1/ziti", "shield")],
+        flags=[
+            "tobogganing.ziti.control_plane",
+            "tobogganing.ziti.sdk_integration",
+        ],
+        entitlements=[
+            Entitlement("ziti.control_plane", "professional"),
+            Entitlement("ziti.sdk_integration", "enterprise"),
+        ],
+        migrations=[],
+        health=None,
+    )

--- a/hub_api/modules/ziti/api/__init__.py
+++ b/hub_api/modules/ziti/api/__init__.py
@@ -1,0 +1,20 @@
+"""Ziti API blueprints."""
+from __future__ import annotations
+
+from quart import Blueprint, jsonify
+
+# Create a minimal health blueprint for the ziti module
+_health_bp = Blueprint("ziti_health", __name__, url_prefix="/api/v1/ziti")
+
+
+@_health_bp.route("/health", methods=["GET"])
+async def health() -> tuple[dict, int]:
+    """Return ziti module scaffold status.
+
+    Returns:
+        Tuple of (response dict, HTTP status code).
+    """
+    return jsonify({"status": "scaffold", "module": "ziti"}), 200
+
+
+blueprints = (_health_bp,)

--- a/hub_api/modules/ziti/models/__init__.py
+++ b/hub_api/modules/ziti/models/__init__.py
@@ -1,0 +1,1 @@
+"""Ziti data models - placeholder for identity and configuration schemas."""

--- a/hub_api/modules/ziti/orchestrator/__init__.py
+++ b/hub_api/modules/ziti/orchestrator/__init__.py
@@ -1,0 +1,1 @@
+"""Ziti orchestrator - placeholder for OpenZiti control-plane management."""

--- a/hub_api/tests/test_ziti_module.py
+++ b/hub_api/tests/test_ziti_module.py
@@ -1,0 +1,107 @@
+"""Tests for the ziti module."""
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+from quart import Quart
+
+from hub_api.modules.ziti import module
+from hub_api.registry import ModuleContext
+
+
+@pytest.mark.asyncio
+async def test_ziti_module_contract() -> None:
+    """Test that the ziti module returns a valid contract.
+
+    Verifies:
+    - Module name is 'ziti'
+    - Feature flags are declared
+    - Entitlements have correct tiers
+    """
+    contract = module()
+
+    assert contract.name == "ziti"
+    assert "tobogganing.ziti.control_plane" in contract.flags
+    assert "tobogganing.ziti.sdk_integration" in contract.flags
+    assert len(contract.flags) == 2
+
+    # Check entitlements
+    feature_tiers = {e.feature: e.tier for e in contract.entitlements}
+    assert feature_tiers["ziti.control_plane"] == "professional"
+    assert feature_tiers["ziti.sdk_integration"] == "enterprise"
+    assert len(contract.entitlements) == 2
+
+    # No migrations for ziti scaffold
+    assert contract.migrations == []
+
+
+@pytest.mark.asyncio
+async def test_ziti_module_nav() -> None:
+    """Test that the ziti module has correct navigation entries.
+
+    Verifies:
+    - Navigation entry label and path
+    - Shield icon is set
+    """
+    contract = module()
+
+    assert len(contract.nav) == 1
+    nav_entry = contract.nav[0]
+    assert nav_entry.label == "Identity"
+    assert nav_entry.path == "/api/v1/ziti"
+    assert nav_entry.icon == "shield"
+
+
+@pytest.mark.asyncio
+async def test_ziti_module_registers_in_app(app: Quart, mock_db: MagicMock) -> None:
+    """Test that the ziti module can be registered with the app without errors.
+
+    Verifies:
+    - Module loads and registers
+    - Blueprint mounts successfully
+    - App boot succeeds with ziti in modules
+    """
+    from hub_api.crypto import InAppKeyProvider, generate_rsa_key_pair
+
+    # Set up key provider for module registration
+    private_pem, public_pem = generate_rsa_key_pair()
+    provider = InAppKeyProvider(private_pem, public_pem)
+    app.config["KEY_PROVIDER"] = provider
+
+    # Apply registry to app (includes ziti module)
+    ctx = ModuleContext(config=app.config_obj, db=mock_db, key_provider=provider)
+    app.registry.apply_to(app, ctx)
+
+    # Verify ziti flags are declared
+    flags = app.registry.declared_flags()
+    assert "tobogganing.ziti.control_plane" in flags
+    assert "tobogganing.ziti.sdk_integration" in flags
+
+
+@pytest.mark.asyncio
+async def test_ziti_module_health_endpoint() -> None:
+    """Test that the ziti health endpoint returns scaffold status.
+
+    Verifies:
+    - Endpoint returns 200 OK
+    - Response indicates module is in scaffold state
+    """
+    import asyncio
+    from quart import Quart
+
+    app = Quart(__name__)
+
+    # Register just the ziti blueprint for this test
+    from hub_api.modules.ziti.api import blueprints
+
+    for bp in blueprints:
+        app.register_blueprint(bp)
+
+    client = app.test_client()
+    response = await client.get("/api/v1/ziti/health")
+
+    assert response.status_code == 200
+    data = await response.get_json()
+    assert data["status"] == "scaffold"
+    assert data["module"] == "ziti"


### PR DESCRIPTION
Phase 5 of the sase → core/sdwan/sase/ziti split. Greenfield scaffold only.

- `hub_api/modules/ziti/` — registered module: `module()` contract (nav Identity, flags `tobogganing.ziti.{control_plane,sdk_integration}`, tiers professional/enterprise), health blueprint, placeholder api/orchestrator/models, roadmap README.
- Added `ziti` to `hub_api/modules/__init__.py::__all__`.
- `test_ziti_module.py` (4 tests).

No OpenZiti SDK dependency added. Boundary-clean (ziti ⊥ sdwan,sase). Suite 843 → 847, app boots with module mounted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)