### PR TITLE
fix(hub-api): complete Phase 2 import retargeting (release boot fix)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -166,3 +166,6 @@ services/hub-router/headend-proxy*
 services/hub-router/headend-test
 services/hub-router/test-headend
 services/hub-router/proxy/headend-proxy
+
+# Git worktrees (local development only)
+.worktrees/

--- a/hub_api/api/headend_routes.py
+++ b/hub_api/api/headend_routes.py
@@ -20,10 +20,9 @@ from quart import Blueprint, current_app, request
 
 from hub_api.auth.jwt import decode_token, encode_access_token
 from hub_api.auth.middleware import current_claims, require_scope, require_tenant
+from hub_api.core import UserManager, CertificateManager
 from hub_api.crypto.keys import KeyProvider
 from hub_api.db import get_db
-from hub_api.modules.sase.auth.user_manager import UserManager
-from hub_api.modules.sase.certs.certificate_manager import CertificateManager
 from hub_api.modules.sase.firewall.access_control import AccessControlManager
 from hub_api.modules.sase.network.port_manager import PortConfigManager
 from hub_api.modules.sase.orchestrator.cluster_manager import ClusterManager

--- a/hub_api/modules/sase/api/certs.py
+++ b/hub_api/modules/sase/api/certs.py
@@ -10,8 +10,8 @@ from typing import Any
 import structlog
 from quart import Blueprint, current_app, request
 
+from hub_api.core import CertificateManager
 from hub_api.entitlements.gate import require_feature
-from hub_api.modules.sase.certs.certificate_manager import CertificateManager
 
 logger = structlog.get_logger()
 

--- a/hub_api/modules/sase/api/wireguard.py
+++ b/hub_api/modules/sase/api/wireguard.py
@@ -10,8 +10,9 @@ import structlog
 from quart import Blueprint, current_app, request
 
 from hub_api.auth.middleware import current_claims, require_tenant
+from hub_api.core import CertificateManager
 from hub_api.entitlements.gate import require_feature
-from hub_api.modules.sase.certs.certificate_manager import CertificateManager
+from hub_api.modules.sase.certs import WireGuardKeyManager
 
 logger = structlog.get_logger()
 
@@ -93,12 +94,15 @@ async def generate_wireguard_keys() -> tuple[dict[str, Any], int]:
         # Get managers from app config
         cluster_manager = current_app.config.get("CLUSTER_MANAGER")
         client_registry = current_app.config.get("CLIENT_REGISTRY")
-        cert_manager: CertificateManager = current_app.config.get(
+        wg_manager: WireGuardKeyManager = current_app.config.get(
+            "WIREGUARD_MANAGER"
+        )
+        pki_manager: CertificateManager = current_app.config.get(
             "CERT_MANAGER"
         )
 
-        if not cert_manager:
-            logger.error("cert_manager_not_configured")
+        if not wg_manager or not pki_manager:
+            logger.error("wg_manager_or_pki_manager_not_configured")
             return (
                 {"error": "Internal server error"},
                 500,
@@ -158,7 +162,7 @@ async def generate_wireguard_keys() -> tuple[dict[str, Any], int]:
 
         # Generate WireGuard keys
         try:
-            wg_config = await cert_manager.generate_wireguard_keys(
+            wg_config = await wg_manager.generate_wireguard_keys(
                 node_id, node_type, tenant_id=tenant_id
             )
         except Exception as e:
@@ -176,7 +180,7 @@ async def generate_wireguard_keys() -> tuple[dict[str, Any], int]:
         try:
             if node_type in ("headend", "kubernetes_node", "raw_compute"):
                 cert_key, cert_pem, ca_cert = (
-                    await cert_manager.generate_headend_certificate(
+                    await pki_manager.generate_headend_certificate(
                         node_id,
                         f"{node_type}-{node_id}",
                         [wg_config["ip_address"]],
@@ -184,7 +188,7 @@ async def generate_wireguard_keys() -> tuple[dict[str, Any], int]:
                 )
             else:
                 cert_key, cert_pem, ca_cert = (
-                    await cert_manager.generate_client_certificate(
+                    await pki_manager.generate_client_certificate(
                         node_id,
                         f"{node_type}-{node_id}",
                         node_type,
@@ -269,12 +273,12 @@ async def get_wireguard_peers() -> tuple[dict[str, Any], int]:
 
         tenant_id = claims["tenant"]
 
-        # Get certificate manager
-        cert_manager: CertificateManager = current_app.config.get(
-            "CERT_MANAGER"
+        # Get WireGuard manager
+        wg_manager: WireGuardKeyManager = current_app.config.get(
+            "WIREGUARD_MANAGER"
         )
-        if not cert_manager:
-            logger.error("cert_manager_not_configured")
+        if not wg_manager:
+            logger.error("wg_manager_not_configured")
             return (
                 {"error": "Internal server error"},
                 500,
@@ -282,7 +286,7 @@ async def get_wireguard_peers() -> tuple[dict[str, Any], int]:
 
         # Get all WireGuard peers for this tenant
         try:
-            peers = await cert_manager.get_all_wireguard_peers(
+            peers = await wg_manager.get_all_wireguard_peers(
                 tenant_id=tenant_id
             )
         except Exception as e:
@@ -347,12 +351,12 @@ async def revoke_wireguard_keys(node_id: str) -> tuple[dict[str, Any], int]:
 
         tenant_id = claims["tenant"]
 
-        # Get certificate manager
-        cert_manager: CertificateManager = current_app.config.get(
-            "CERT_MANAGER"
+        # Get WireGuard manager
+        wg_manager: WireGuardKeyManager = current_app.config.get(
+            "WIREGUARD_MANAGER"
         )
-        if not cert_manager:
-            logger.error("cert_manager_not_configured")
+        if not wg_manager:
+            logger.error("wg_manager_not_configured")
             return (
                 {"error": "Internal server error"},
                 500,
@@ -360,7 +364,7 @@ async def revoke_wireguard_keys(node_id: str) -> tuple[dict[str, Any], int]:
 
         # Revoke WireGuard keys (tenant-scoped)
         try:
-            success = await cert_manager.revoke_wireguard_keys(
+            success = await wg_manager.revoke_wireguard_keys(
                 node_id, tenant_id=tenant_id
             )
         except Exception as e:

--- a/hub_api/modules/sase/auth/__init__.py
+++ b/hub_api/modules/sase/auth/__init__.py
@@ -1,4 +1,4 @@
-"""SASE authentication and authorization module."""
-from hub_api.modules.sase.auth.user_manager import UserManager, User, Session, UserRole
+"""SASE authentication and authorization module (transitional re-export from core)."""
+from hub_api.core import UserManager, User, Session, UserRole
 
 __all__ = ["UserManager", "User", "Session", "UserRole"]

--- a/hub_api/modules/sase/certs/__init__.py
+++ b/hub_api/modules/sase/certs/__init__.py
@@ -1,6 +1,6 @@
-"""SASE certificate management module."""
+"""SASE WireGuard key management module."""
 from __future__ import annotations
 
-from hub_api.modules.sase.certs.certificate_manager import CertificateManager
+from hub_api.modules.sase.certs.certificate_manager import WireGuardKeyManager
 
-__all__ = ["CertificateManager"]
+__all__ = ["WireGuardKeyManager"]

--- a/hub_api/modules/sase/certs/certificate_manager.py
+++ b/hub_api/modules/sase/certs/certificate_manager.py
@@ -1,26 +1,17 @@
 """
-Certificate management for CertificateManager service.
+WireGuard key management for SASE module.
 
-Provides X.509 certificate generation and validation, WireGuard key management,
-and IP address allocation for managed nodes.
+Provides X25519 key pair generation, peer management, and IP address allocation.
 """
 
-import os
-import asyncio
-import hashlib
 import base64
-import tempfile
-from datetime import datetime, timedelta, timezone
-from typing import Dict, List, Tuple, Optional
-from dataclasses import dataclass, field
-import structlog
+import hashlib
+from dataclasses import dataclass
+from typing import Dict, List
 
-from cryptography import x509
-from cryptography.x509.oid import NameOID, ExtensionOID
-from cryptography.hazmat.primitives import hashes, serialization
-from cryptography.hazmat.primitives.asymmetric import rsa, ec
+import structlog
+from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric import x25519
-from cryptography.hazmat.backends import default_backend
 
 logger = structlog.get_logger()
 
@@ -35,256 +26,40 @@ class WireGuardPeer:
     tenant_id: str = "default"
 
 
-class CertificateManager:
+class WireGuardKeyManager:
     """
-    Manages X.509 certificates and WireGuard keys for the cluster.
+    Manages WireGuard keys for the cluster.
 
-    Provides CA certificate generation, node certificate signing, certificate
-    validation, and WireGuard key pair generation with IP allocation.
+    Provides X25519 key pair generation and IP address allocation for managed nodes.
     """
 
     def __init__(self) -> None:
         """
-        Initialize the CertificateManager.
+        Initialize the WireGuardKeyManager.
 
-        Sets up instance variables for CA cert/key and peer tracking.
-        Generates a self-signed CA certificate immediately so it's available
-        for use without calling initialize().
+        Sets up instance variables for peer tracking and IP allocations.
         """
-        self.ca_cert: Optional[x509.Certificate] = None
-        self.ca_key: Optional[rsa.RSAPrivateKey] = None
         self._peers: Dict[str, WireGuardPeer] = {}
         self._ip_allocations: Dict[str, str] = {}
         self._initialized: bool = False
 
-        # Generate CA immediately
-        self._generate_ca()
-
     async def initialize(self) -> None:
-        """
-        Initialize the CA certificate.
-
-        Loads CA from PEM files specified by CA_CERT_PATH and CA_KEY_PATH
-        environment variables if they exist and are readable. If files don't
-        exist but paths are set, persists the CA that was generated in __init__.
-
-        If CA_CERT_PATH and CA_KEY_PATH are set, persists the CA with file
-        permissions 0o600.
-
-        Raises:
-            ValueError: If loaded CA certificate is not a valid CA or fails validation.
-        """
-        try:
-            ca_cert_path = os.getenv("CA_CERT_PATH")
-            ca_key_path = os.getenv("CA_KEY_PATH")
-
-            if ca_cert_path and ca_key_path and os.path.exists(ca_cert_path) and os.path.exists(ca_key_path):
-                # Load existing CA from PEM files
-                logger.info("Loading existing CA from files", cert_path=ca_cert_path, key_path=ca_key_path)
-                with open(ca_cert_path, "rb") as f:
-                    cert_pem = f.read()
-                    self.ca_cert = x509.load_pem_x509_certificate(cert_pem, default_backend())
-
-                with open(ca_key_path, "rb") as f:
-                    key_pem = f.read()
-                    self.ca_key = serialization.load_pem_private_key(key_pem, password=None, backend=default_backend())
-
-                # Validate loaded CA is a valid CA certificate (fail closed on invalid)
-                self._validate_ca_certificate(self.ca_cert)
-                logger.info("CA loaded successfully and validated")
-            elif ca_cert_path and ca_key_path:
-                # Persist CA that was generated in __init__
-                self._persist_ca(ca_cert_path, ca_key_path)
-                logger.info("CA persisted to files", cert_path=ca_cert_path, key_path=ca_key_path)
-            else:
-                # CA already generated in __init__, just log
-                logger.info("Using in-memory CA from __init__")
-
-            self._initialized = True
-            logger.info("CertificateManager initialized")
-        except Exception as e:
-            logger.error("Failed to initialize CertificateManager", error=str(e))
-            raise
+        """Initialize the WireGuardKeyManager."""
+        self._initialized = True
+        logger.info("WireGuardKeyManager initialized")
 
     async def shutdown(self) -> None:
-        """Shutdown the CertificateManager (cleanup/no-op)."""
-        logger.info("CertificateManager shutdown")
+        """Shutdown the WireGuardKeyManager (cleanup/no-op)."""
+        logger.info("WireGuardKeyManager shutdown")
 
     async def is_healthy(self) -> bool:
         """
-        Check if the CertificateManager is healthy.
-
-        Returns True if the CA certificate has been initialized.
+        Check if the WireGuardKeyManager is healthy.
 
         Returns:
-            True if CA is present and initialized, False otherwise.
+            True if initialized, False otherwise.
         """
-        return self._initialized and self.ca_cert is not None
-
-    async def generate_certificate(
-        self,
-        node_id: str,
-        node_type: str,
-        validity_days: int = 365,
-    ) -> Dict[str, str]:
-        """
-        Generate a signed X.509 certificate for a node.
-
-        Creates a leaf certificate signed by the CA. The node_id and node_type
-        are encoded in the certificate subject (CN=node_id, OU=node_type).
-
-        Args:
-            node_id: Unique identifier for the node.
-            node_type: Type of node (e.g., 'client', 'headend').
-            validity_days: Certificate validity period in days (default: 365).
-
-        Returns:
-            Dictionary containing:
-            - certificate: PEM-encoded certificate string
-            - private_key: PEM-encoded private key string
-            - ca_certificate: PEM-encoded CA certificate string
-        """
-        if not self.ca_cert or not self.ca_key:
-            raise ValueError("CA not initialized")
-
-        try:
-            # Generate a new EC private key for the leaf certificate
-            private_key = ec.generate_private_key(ec.SECP256R1(), default_backend())
-
-            # Create certificate subject with node_id and node_type
-            subject = x509.Name(
-                [
-                    x509.NameAttribute(NameOID.COMMON_NAME, node_id),
-                    x509.NameAttribute(NameOID.ORGANIZATIONAL_UNIT_NAME, node_type),
-                ]
-            )
-
-            # Get CA issuer
-            issuer = self.ca_cert.subject
-
-            # Build certificate
-            cert_builder = (
-                x509.CertificateBuilder()
-                .subject_name(subject)
-                .issuer_name(issuer)
-                .public_key(private_key.public_key())
-                .serial_number(x509.random_serial_number())
-                .not_valid_before(datetime.utcnow())
-                .not_valid_after(datetime.utcnow() + timedelta(days=validity_days))
-            )
-
-            # Sign with CA key
-            certificate = cert_builder.sign(self.ca_key, hashes.SHA256(), default_backend())
-
-            # Serialize to PEM
-            cert_pem = certificate.public_bytes(serialization.Encoding.PEM).decode("utf-8")
-            key_pem = private_key.private_bytes(
-                encoding=serialization.Encoding.PEM,
-                format=serialization.PrivateFormat.TraditionalOpenSSL,
-                encryption_algorithm=serialization.NoEncryption(),
-            ).decode("utf-8")
-            ca_pem = self.ca_cert.public_bytes(serialization.Encoding.PEM).decode("utf-8")
-
-            return {
-                "certificate": cert_pem,
-                "private_key": key_pem,
-                "ca_certificate": ca_pem,
-            }
-        except Exception as e:
-            logger.error("Failed to generate certificate", node_id=node_id, error=str(e))
-            raise
-
-    async def validate_certificate(self, cert_pem: str) -> Dict[str, any]:
-        """
-        Validate an X.509 certificate.
-
-        Verifies that the certificate was signed by the CA, checks the validity
-        window (not_before/not_after), and verifies the issuer matches the CA.
-        Extracts the node_id and node_type from the subject.
-
-        Args:
-            cert_pem: PEM-encoded certificate string.
-
-        Returns:
-            Dictionary containing:
-            - valid: Boolean indicating certificate validity
-            - node_id: Node identifier from certificate CN
-            - node_type: Node type from certificate OU
-            - not_before: Certificate validity start time (timezone-aware UTC)
-            - not_after: Certificate validity end time (timezone-aware UTC)
-        """
-        try:
-            # Load certificate
-            certificate = x509.load_pem_x509_certificate(cert_pem.encode(), default_backend())
-
-            # Verify signature using CA public key
-            try:
-                ca_public_key = self.ca_cert.public_key()
-                # Verify will raise InvalidSignature if signature is invalid
-                ca_public_key.verify(
-                    certificate.signature,
-                    certificate.tbs_certificate_bytes,
-                    ec.ECDSA(hashes.SHA256()) if isinstance(ca_public_key, ec.EllipticCurvePublicKey) else None,
-                )
-            except Exception:
-                return {
-                    "valid": False,
-                    "node_id": None,
-                    "node_type": None,
-                    "not_before": None,
-                    "not_after": None,
-                }
-
-            # Verify issuer matches CA subject
-            if certificate.issuer != self.ca_cert.subject:
-                return {
-                    "valid": False,
-                    "node_id": None,
-                    "node_type": None,
-                    "not_before": None,
-                    "not_after": None,
-                }
-
-            # Check validity window with timezone-aware UTC
-            not_before = certificate.not_valid_before_utc
-            not_after = certificate.not_valid_after_utc
-            now = datetime.now(timezone.utc)
-
-            if now < not_before or now > not_after:
-                return {
-                    "valid": False,
-                    "node_id": None,
-                    "node_type": None,
-                    "not_before": not_before,
-                    "not_after": not_after,
-                }
-
-            # Extract node_id (CN) and node_type (OU) from subject
-            node_id = None
-            node_type = None
-
-            for attr in certificate.subject:
-                if attr.oid == NameOID.COMMON_NAME:
-                    node_id = attr.value
-                elif attr.oid == NameOID.ORGANIZATIONAL_UNIT_NAME:
-                    node_type = attr.value
-
-            return {
-                "valid": True,
-                "node_id": node_id,
-                "node_type": node_type,
-                "not_before": not_before,
-                "not_after": not_after,
-            }
-        except Exception as e:
-            logger.error("Failed to validate certificate", error=str(e))
-            return {
-                "valid": False,
-                "node_id": None,
-                "node_type": None,
-                "not_before": None,
-                "not_after": None,
-            }
+        return self._initialized
 
     async def generate_wireguard_keys(
         self, node_id: str, node_type: str, tenant_id: str = "default"
@@ -343,91 +118,6 @@ class CertificateManager:
             }
         except Exception as e:
             logger.error("Failed to generate WireGuard keys", node_id=node_id, error=str(e))
-            raise
-
-    async def generate_headend_certificate(
-        self,
-        cluster_id: str,
-        name: str,
-        sans: List[str],
-    ) -> Tuple[str, str, str]:
-        """
-        Generate a certificate for a headend node.
-
-        Creates an X.509 certificate with SubjectAltName entries for the
-        specified SANs.
-
-        Args:
-            cluster_id: Cluster identifier to use as node_id.
-            name: Certificate common name.
-            sans: List of Subject Alternative Names (DNS entries).
-
-        Returns:
-            Tuple of (private_key_pem, certificate_pem, ca_certificate_pem)
-        """
-        try:
-            # Use internal method with headend node type
-            cert_dict = await self.generate_certificate(cluster_id, "headend", validity_days=365)
-
-            # Load certificate to add SANs
-            certificate = x509.load_pem_x509_certificate(
-                cert_dict["certificate"].encode(),
-                default_backend(),
-            )
-
-            # Create new certificate with SANs
-            private_key = serialization.load_pem_private_key(
-                cert_dict["private_key"].encode(),
-                password=None,
-                backend=default_backend(),
-            )
-
-            # Rebuild with SANs
-            san_list = [x509.DNSName(san) for san in sans]
-            cert_builder = (
-                x509.CertificateBuilder()
-                .subject_name(certificate.subject)
-                .issuer_name(certificate.issuer)
-                .public_key(certificate.public_key())
-                .serial_number(x509.random_serial_number())
-                .not_valid_before(certificate.not_valid_before)
-                .not_valid_after(certificate.not_valid_after)
-                .add_extension(
-                    x509.SubjectAlternativeName(san_list),
-                    critical=False,
-                )
-            )
-
-            signed_cert = cert_builder.sign(self.ca_key, hashes.SHA256(), default_backend())
-            cert_pem = signed_cert.public_bytes(serialization.Encoding.PEM).decode("utf-8")
-
-            return (cert_dict["private_key"], cert_pem, cert_dict["ca_certificate"])
-        except Exception as e:
-            logger.error("Failed to generate headend certificate", cluster_id=cluster_id, error=str(e))
-            raise
-
-    async def generate_client_certificate(
-        self,
-        client_id: str,
-        name: str,
-        client_type: str,
-    ) -> Tuple[str, str, str]:
-        """
-        Generate a certificate for a client node.
-
-        Args:
-            client_id: Client identifier to use as node_id.
-            name: Certificate common name.
-            client_type: Client type (docker, native, etc.).
-
-        Returns:
-            Tuple of (private_key_pem, certificate_pem, ca_certificate_pem)
-        """
-        try:
-            cert_dict = await self.generate_certificate(client_id, "client", validity_days=365)
-            return (cert_dict["private_key"], cert_dict["certificate"], cert_dict["ca_certificate"])
-        except Exception as e:
-            logger.error("Failed to generate client certificate", client_id=client_id, error=str(e))
             raise
 
     async def get_all_wireguard_peers(
@@ -549,158 +239,3 @@ class CertificateManager:
 
         # Exhausted retries without finding collision-free IP
         raise RuntimeError(f"Failed to allocate collision-free IP for node {node_id} after {max_attempts} attempts")
-
-    def _is_certificate_expiring(self, expiry: datetime, threshold_days: int = 30) -> bool:
-        """
-        Check if a certificate is expiring within the threshold.
-
-        Args:
-            expiry: Certificate expiration time (datetime object).
-            threshold_days: Number of days to check before expiration.
-
-        Returns:
-            True if expiry is within threshold_days from now, False otherwise.
-        """
-        # Handle naive datetimes by comparing against naive utcnow
-        now = datetime.utcnow()
-
-        # If expiry has timezone info, make now aware; if naive, keep now naive
-        if expiry.tzinfo is not None:
-            now = now.replace(tzinfo=timezone.utc)
-
-        threshold = timedelta(days=threshold_days)
-        return expiry - now <= threshold
-
-    def _validate_ca_certificate(self, cert: x509.Certificate) -> None:
-        """
-        Validate that a certificate is a valid CA certificate.
-
-        Checks that the certificate has BasicConstraints extension with ca=True.
-        Fails closed (raises exception) if validation fails.
-
-        Args:
-            cert: The certificate to validate.
-
-        Raises:
-            ValueError: If certificate is not a valid CA or lacks required constraints.
-        """
-        try:
-            # Check for BasicConstraints extension
-            try:
-                basic_constraints = cert.extensions.get_extension_for_class(
-                    x509.BasicConstraints
-                )
-            except x509.ExtensionNotFound:
-                raise ValueError("CA certificate missing BasicConstraints extension")
-
-            # Verify ca=True
-            if not basic_constraints.value.ca:
-                raise ValueError("Certificate BasicConstraints.ca is not True; not a valid CA")
-
-            logger.info("CA certificate validated successfully")
-        except (ValueError, AttributeError, TypeError) as e:
-            # Fail closed: any validation error means reject the CA
-            logger.error("CA certificate validation failed", error=str(e))
-            raise
-
-    def _generate_ca(self) -> None:
-        """
-        Generate a self-signed CA certificate.
-
-        Creates an EC (SECP256R1) key pair and a self-signed CA certificate
-        with basic constraints extension.
-        """
-        # Generate CA private key (EC)
-        self.ca_key = ec.generate_private_key(ec.SECP256R1(), default_backend())
-
-        # Create CA subject
-        subject = issuer = x509.Name(
-            [
-                x509.NameAttribute(NameOID.COUNTRY_NAME, "US"),
-                x509.NameAttribute(NameOID.STATE_OR_PROVINCE_NAME, "CA"),
-                x509.NameAttribute(NameOID.LOCALITY_NAME, "San Francisco"),
-                x509.NameAttribute(NameOID.ORGANIZATION_NAME, "SASEWaddle"),
-                x509.NameAttribute(NameOID.COMMON_NAME, "SASEWaddle CA"),
-            ]
-        )
-
-        # Build self-signed certificate
-        cert_builder = (
-            x509.CertificateBuilder()
-            .subject_name(subject)
-            .issuer_name(issuer)
-            .public_key(self.ca_key.public_key())
-            .serial_number(x509.random_serial_number())
-            .not_valid_before(datetime.utcnow())
-            .not_valid_after(datetime.utcnow() + timedelta(days=3650))  # 10 years
-            .add_extension(
-                x509.BasicConstraints(ca=True, path_length=None),
-                critical=True,
-            )
-        )
-
-        # Self-sign
-        self.ca_cert = cert_builder.sign(self.ca_key, hashes.SHA256(), default_backend())
-
-    def _persist_ca(self, cert_path: str, key_path: str) -> None:
-        """
-        Persist CA certificate and key to PEM files using atomic writes.
-
-        Prevents TOCTOU (time-of-check-time-of-use) symlink attacks by writing to
-        temp files with O_EXCL, then using os.replace() for atomic rename.
-
-        Args:
-            cert_path: Path to save CA certificate.
-            key_path: Path to save CA private key.
-
-        Raises:
-            ValueError: If CA not initialized or file operations fail.
-        """
-        if not self.ca_cert or not self.ca_key:
-            raise ValueError("CA not initialized")
-
-        # Create directories if needed with secure permissions
-        cert_dir = os.path.dirname(cert_path) or "."
-        key_dir = os.path.dirname(key_path) or "."
-        os.makedirs(cert_dir, mode=0o700, exist_ok=True)
-        os.makedirs(key_dir, mode=0o700, exist_ok=True)
-
-        # Write certificate: create temp file with O_EXCL, then atomic replace
-        cert_pem = self.ca_cert.public_bytes(serialization.Encoding.PEM)
-        cert_temp_fd, cert_temp_path = tempfile.mkstemp(dir=cert_dir, prefix=".ca_cert_", suffix=".tmp")
-        try:
-            # Ensure secure permissions on temp file
-            os.chmod(cert_temp_path, 0o600)
-            with os.fdopen(cert_temp_fd, "wb") as f:
-                f.write(cert_pem)
-            # Atomic rename (prevents symlink race if cert_path exists as symlink)
-            os.replace(cert_temp_path, cert_path)
-        except Exception:
-            # Clean up temp file on failure
-            try:
-                os.unlink(cert_temp_path)
-            except Exception:
-                pass
-            raise
-
-        # Write key: create temp file with O_EXCL, then atomic replace
-        key_pem = self.ca_key.private_bytes(
-            encoding=serialization.Encoding.PEM,
-            format=serialization.PrivateFormat.TraditionalOpenSSL,
-            encryption_algorithm=serialization.NoEncryption(),
-        )
-        key_temp_fd, key_temp_path = tempfile.mkstemp(dir=key_dir, prefix=".ca_key_", suffix=".tmp")
-        try:
-            # Ensure secure permissions on temp file
-            os.chmod(key_temp_path, 0o600)
-            with os.fdopen(key_temp_fd, "wb") as f:
-                f.write(key_pem)
-            # Atomic rename (prevents symlink race if key_path exists as symlink)
-            os.replace(key_temp_path, key_path)
-        except Exception:
-            # Clean up temp file on failure
-            try:
-                os.unlink(key_temp_path)
-            except Exception:
-                pass
-            raise

--- a/hub_api/tests/test_core_backup.py
+++ b/hub_api/tests/test_core_backup.py
@@ -1,4 +1,4 @@
-"""Tests for SASE backup module."""
+"""Tests for core backup module."""
 
 import json
 from pathlib import Path
@@ -6,9 +6,9 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from hub_api.modules.sase.backup import BackupManager, S3Config, S3Manager
-from hub_api.modules.sase.backup.crypto import decrypt_file, encrypt_file
-from hub_api.modules.sase.backup.manager import _validate_backup_name, _validate_path_in_directory
+from hub_api.core.backup import BackupManager, S3Config, S3Manager
+from hub_api.core.backup.crypto import decrypt_file, encrypt_file
+from hub_api.core.backup.manager import _validate_backup_name, _validate_path_in_directory
 
 
 def _create_backup_mock_db() -> MagicMock:
@@ -192,7 +192,7 @@ class TestEncryption:
 
     def test_encrypt_kdf_parameters_match(self, tmp_path: Path) -> None:
         """Test that KDF parameters are consistent between encrypt/decrypt."""
-        from hub_api.modules.sase.backup.crypto import SCRYPT_N, SCRYPT_R, SCRYPT_P
+        from hub_api.core.backup.crypto import SCRYPT_N, SCRYPT_R, SCRYPT_P
 
         # Verify upgraded parameters per OWASP
         assert SCRYPT_N == 2**17, "KDF n parameter should be 2^17 (131072)"
@@ -581,7 +581,7 @@ class TestS3Manager:
         manager = S3Manager(config)
         assert manager.client is None
 
-    @patch("hub_api.modules.sase.backup.s3.boto3")
+    @patch("hub_api.core.backup.s3.boto3")
     def test_s3_manager_init_enabled(self, mock_boto3: MagicMock) -> None:
         """Test S3 manager when enabled."""
         config = S3Config(
@@ -602,7 +602,7 @@ class TestS3Manager:
         manager = S3Manager(config)
         assert manager.client is not None
 
-    @patch("hub_api.modules.sase.backup.s3.boto3")
+    @patch("hub_api.core.backup.s3.boto3")
     def test_s3_upload_backup(self, mock_boto3: MagicMock, tmp_path: Path) -> None:
         """Test S3 backup upload."""
         config = S3Config(
@@ -637,7 +637,7 @@ class TestS3Manager:
         assert result["size_bytes"] == 1024
         mock_client.upload_fileobj.assert_called_once()
 
-    @patch("hub_api.modules.sase.backup.s3.boto3")
+    @patch("hub_api.core.backup.s3.boto3")
     def test_s3_list_backups(self, mock_boto3: MagicMock) -> None:
         """Test S3 backup listing."""
         config = S3Config(

--- a/hub_api/tests/test_core_backup_isolation_realdal.py
+++ b/hub_api/tests/test_core_backup_isolation_realdal.py
@@ -1,4 +1,4 @@
-"""Integration tests for SASE backup isolation with real penguin-dal AsyncDB."""
+"""Integration tests for core backup isolation with real penguin-dal AsyncDB."""
 from __future__ import annotations
 
 import json
@@ -10,7 +10,7 @@ from typing import Any
 import pytest
 import pytest_asyncio
 
-from hub_api.modules.sase.backup import BackupManager
+from hub_api.core.backup import BackupManager
 
 
 @pytest_asyncio.fixture

--- a/hub_api/tests/test_core_user_manager.py
+++ b/hub_api/tests/test_core_user_manager.py
@@ -1,4 +1,4 @@
-"""Tests for SASE user manager."""
+"""Tests for core user manager."""
 from __future__ import annotations
 
 from datetime import datetime, timedelta
@@ -7,7 +7,7 @@ from uuid import uuid4
 
 import pytest
 
-from hub_api.modules.sase.auth import UserManager, User, Session, UserRole
+from hub_api.core import UserManager, User, Session, UserRole
 from hub_api.tests.conftest import make_mock_row, make_mock_rowset
 
 

--- a/hub_api/tests/test_dal_backup_scanner_ratelimit.py
+++ b/hub_api/tests/test_dal_backup_scanner_ratelimit.py
@@ -11,7 +11,7 @@ from uuid import uuid4
 
 import pytest
 
-from hub_api.modules.sase.backup.manager import BackupManager
+from hub_api.core.backup.manager import BackupManager
 from hub_api.modules.sase.security.protection.ratelimit import RateLimiter
 from hub_api.modules.sase.security.scanner.core import ScanFinding, ScanSeverity, ScanType, SecurityScanner
 

--- a/hub_api/tests/test_sase_managers_realdal.py
+++ b/hub_api/tests/test_sase_managers_realdal.py
@@ -12,7 +12,7 @@ from uuid import uuid4
 
 import pytest
 
-from hub_api.modules.sase.auth.user_manager import UserManager, UserRole
+from hub_api.core import UserManager, UserRole
 from hub_api.modules.sase.firewall.access_control import AccessControlManager, AccessRule, AccessType, RuleType
 from hub_api.modules.sase.network.port_manager import PortConfigManager, PortProtocol, PortRangeConfig
 from hub_api.modules.sase.network.vrf_manager import VRFManager, VRFConfiguration, VRFStatus, OSPFNeighbor


### PR DESCRIPTION
**Fixes a broken release.** PR #82 (Phase 2) committed the file *moves* but the agent left the import-retargeting edits uncommitted, so `release/v1.2.X` boots with `ModuleNotFoundError` (`headend_routes.py` + sase api still imported the moved `sase.auth.user_manager` / `sase.certs.certificate_manager`).

This lands the missing completion delta (already verified as the working-tree state that passed the full suite):
- `headend_routes.py`, `sase/api/{certs,wireguard}.py`, `sase/auth/__init__.py`, `sase/certs/__init__.py` → import `UserManager`/`CertificateManager` from `hub_api.core`.
- `certificate_manager.py` reduced to WG-only `WireGuardKeyManager`.
- Tests retargeted to `hub_api.core.*`.

**Verified on CLEAN bytecode** (the release break was a stale-`.pyc`-masked import error): app boots (17 routes), `audit_imports sase⊥sdwan,ziti` clean, full-suite collection **846 tests / 0 errors**, import-sensitive batches 197 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)