### PR TITLE
fix(hub-api): track sdwan/certs package (release boot fix)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,9 +24,10 @@ certs/
 certificates/
 secrets/
 .secrets
-# ...but the SASE certs source package is code, not TLS material — keep it tracked
-!core/modules/sase/certs/
-!core/modules/sase/certs/**
+# ...but module certs/ source packages are code, not TLS material — keep tracked
+# (path is hub_api/modules/*/certs/ after the core->hub_api rename; covers sase, sdwan, etc.)
+!hub_api/modules/**/certs/
+!hub_api/modules/**/certs/**
 
 # Configuration files with sensitive data
 config.yaml

--- a/hub_api/modules/sdwan/certs/__init__.py
+++ b/hub_api/modules/sdwan/certs/__init__.py
@@ -1,0 +1,10 @@
+"""SDWAN WireGuard key management package.
+
+Re-exports the WireGuard key manager so callers can import it from the package
+root without reaching into the implementation module.
+"""
+from __future__ import annotations
+
+from hub_api.modules.sdwan.certs.wireguard_manager import WireGuardKeyManager
+
+__all__ = ["WireGuardKeyManager"]


### PR DESCRIPTION
**Un-breaks release** (post-#84 boot failure). The `.gitignore` bare `certs/` rule matched `hub_api/modules/sdwan/certs/`, so the new `sdwan/certs/__init__.py` was silently skipped by `git add -A` (invisible in `git status`) → release booted with `ImportError: cannot import name 'WireGuardKeyManager' from hub_api.modules.sdwan.certs`. The existing negation used the stale pre-rename path `core/modules/sase/certs/`.

- `.gitignore`: negate all module certs/ source packages (`hub_api/modules/**/certs/**`).
- Add the missing `sdwan/certs/__init__.py` (re-exports `WireGuardKeyManager`).

**Verified:** collection 735/7-errors → **850/0 errors**; boot OK; audit `sdwan⊥{sase,ziti}` clean; WG runtime tests 33 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)