### PR TITLE
refactor(hub-api): Phase 4 — reduce sase to security + context-auth (split complete)

### DIFF
--- a/hub_api/app.py
+++ b/hub_api/app.py
@@ -62,12 +62,17 @@ def create_app(config: Config | None = None) -> Quart:
     from hub_api.api.auth_routes import auth_bp
     from hub_api.api.portal_routes import portal_bp
     from hub_api.api.headend_routes import headend_bp
+    from hub_api.core.api import certs_blueprint, jwt_blueprint
 
     app.register_blueprint(auth_bp)
     app.register_blueprint(portal_bp)
     # Headend routes: flat app-level paths for hub-router headend service
     # Registered at app level (url_prefix='/api/v1') to bypass module prefixing
     app.register_blueprint(headend_bp, url_prefix="/api/v1")
+    # Core API blueprints: certificate and JWT management
+    # Registered directly (blueprints define their own full /api/v1/* prefixes)
+    app.register_blueprint(certs_blueprint)
+    app.register_blueprint(jwt_blueprint)
 
     # Set DATABASE_URI for penguin-dal init_dal()
     db_uri = build_db_uri(config)

--- a/hub_api/core/api/__init__.py
+++ b/hub_api/core/api/__init__.py
@@ -1,0 +1,7 @@
+"""Core API blueprints."""
+from __future__ import annotations
+
+from hub_api.core.api.certs import blueprint as certs_blueprint
+from hub_api.core.api.jwt import blueprint as jwt_blueprint
+
+__all__ = ["certs_blueprint", "jwt_blueprint"]

--- a/hub_api/core/api/certs.py
+++ b/hub_api/core/api/certs.py
@@ -1,4 +1,4 @@
-"""Certificate management blueprint for SASE module."""
+"""Certificate management blueprint for core module."""
 from __future__ import annotations
 
 import hmac
@@ -15,7 +15,7 @@ from hub_api.entitlements.gate import require_feature
 
 logger = structlog.get_logger()
 
-blueprint = Blueprint("sase_certs", __name__, url_prefix="/certs")
+blueprint = Blueprint("core_certs", __name__, url_prefix="/api/v1/certs")
 
 
 @dataclass(slots=True)

--- a/hub_api/core/api/jwt.py
+++ b/hub_api/core/api/jwt.py
@@ -1,4 +1,4 @@
-"""JWT authentication blueprint for SASE module."""
+"""JWT authentication blueprint for core module."""
 
 from __future__ import annotations
 
@@ -16,7 +16,7 @@ from hub_api.entitlements.gate import require_feature
 
 logger = structlog.get_logger()
 
-blueprint = Blueprint("sase_jwt", __name__, url_prefix="/jwt")
+blueprint = Blueprint("core_jwt", __name__, url_prefix="/api/v1/jwt")
 
 # In-memory revocation list (Phase-2 placeholder; will move to DB in Phase-3)
 _REVOKED_TOKENS: set[str] = set()

--- a/hub_api/modules/sase/__init__.py
+++ b/hub_api/modules/sase/__init__.py
@@ -1,4 +1,4 @@
-"""SASE module - Security and Access Service Edge control plane."""
+"""SASE module - Security inspection and context-based authentication."""
 from __future__ import annotations
 
 from hub_api.modules.sase.api import blueprints
@@ -9,21 +9,25 @@ def module() -> ModuleContract:
     """Return the module contract for the SASE module.
 
     Returns:
-        ModuleContract with SASE blueprints, feature flags, entitlements,
+        ModuleContract with SASE security blueprints, feature flags, entitlements,
         navigation entries, and migration history.
     """
     return ModuleContract(
         name="sase",
         blueprints=list(blueprints),
-        nav=[],
+        nav=[NavEntry("Security", "/api/v1/sase/security", "shield")],
         flags=[
-            "tobogganing.sase.certs",
-            "tobogganing.sase.auth",
+            "tobogganing.sase.threat_feeds",
+            "tobogganing.sase.scanner",
+            "tobogganing.sase.protection",
+            "tobogganing.sase.context_auth",
         ],
         entitlements=[
-            Entitlement("sase.certs", "community"),
-            Entitlement("sase.auth", "community"),
+            Entitlement("sase.threat_feeds", "community"),
+            Entitlement("sase.scanner", "community"),
+            Entitlement("sase.protection", "community"),
+            Entitlement("sase.context_auth", "professional"),
         ],
-        migrations=["0005", "0006", "0008"],
+        migrations=["0006", "0008"],
         health=None,
     )

--- a/hub_api/modules/sase/api/__init__.py
+++ b/hub_api/modules/sase/api/__init__.py
@@ -1,12 +1,6 @@
 """SASE API blueprints."""
 from __future__ import annotations
 
-from hub_api.modules.sase.api.certs import blueprint as certs_blueprint
-from hub_api.modules.sase.api.jwt import blueprint as jwt_blueprint
-
-blueprints = [
-    certs_blueprint,
-    jwt_blueprint,
-]
+blueprints: list = []
 
 __all__ = ["blueprints"]

--- a/hub_api/modules/sase/auth/context.py
+++ b/hub_api/modules/sase/auth/context.py
@@ -1,0 +1,38 @@
+"""Context-based authentication evaluator for SASE module.
+
+Provides threat-intelligence lookup, impossible-travel detection, and
+risk-based step-up for adaptive authentication. Scaffold phase: safe defaults.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(slots=True)
+class ContextAuthDecision:
+    """Decision outcome from context-based auth evaluation."""
+
+    allowed: bool
+    reason: str
+
+
+class ContextAuthEvaluator:
+    """Evaluate authentication context for risk-based access control.
+
+    Phase-1 scaffold: stub implementation with safe defaults (allow).
+    Future phases will integrate threat-intel feeds, geo-IP databases,
+    and behavioral analytics for adaptive authentication.
+    """
+
+    def evaluate(self, context: dict) -> ContextAuthDecision:
+        """Evaluate authentication context and return allow/deny decision.
+
+        Args:
+            context: Authentication context (node_id, tenant, location, etc.).
+
+        Returns:
+            ContextAuthDecision with allow=True and reason (stub always allows).
+        """
+        # Phase-1: safe default — allow all requests
+        # Future: check threat feeds, impossible travel, risk scores
+        return ContextAuthDecision(allowed=True, reason="context_auth_not_implemented")

--- a/hub_api/modules/sase/web/__init__.py
+++ b/hub_api/modules/sase/web/__init__.py
@@ -1,1 +1,0 @@
-"""SASE web interface blueprints."""

--- a/hub_api/tests/test_sase_api_crypto.py
+++ b/hub_api/tests/test_sase_api_crypto.py
@@ -142,7 +142,7 @@ async def test_certificate_generation_requires_enrollment_token(
 
         # Request without Authorization header
         response = await client.post(
-            "/api/v1/sase/certs/certificates",
+            "/api/v1/certs/certificates",
             json={
                 "type": "client",
                 "id": "node-1",
@@ -170,7 +170,7 @@ async def test_certificate_generation_with_invalid_token(
         mock_flag.return_value = True
 
         response = await client.post(
-            "/api/v1/sase/certs/certificates",
+            "/api/v1/certs/certificates",
             json={
                 "type": "client",
                 "id": "node-1",
@@ -198,7 +198,7 @@ async def test_certificate_generation_client_success(
         mock_flag.return_value = True
 
         response = await client.post(
-            "/api/v1/sase/certs/certificates",
+            "/api/v1/certs/certificates",
             json={
                 "type": "client",
                 "id": "client-1",
@@ -235,7 +235,7 @@ async def test_certificate_generation_headend_success(
         mock_flag.return_value = True
 
         response = await client.post(
-            "/api/v1/sase/certs/certificates",
+            "/api/v1/certs/certificates",
             json={
                 "type": "headend",
                 "id": "headend-1",
@@ -267,7 +267,7 @@ async def test_certificate_generation_invalid_type(
         mock_flag.return_value = True
 
         response = await client.post(
-            "/api/v1/sase/certs/certificates",
+            "/api/v1/certs/certificates",
             json={
                 "type": "invalid_type",
                 "id": "node-1",
@@ -297,7 +297,7 @@ async def test_certificate_generation_flag_off(
         mock_flag.return_value = False
 
         response = await client.post(
-            "/api/v1/sase/certs/certificates",
+            "/api/v1/certs/certificates",
             json={
                 "type": "client",
                 "id": "node-1",
@@ -330,7 +330,7 @@ async def test_jwt_token_generation_missing_fields(
         mock_flag.return_value = True
 
         response = await client.post(
-            "/api/v1/sase/jwt/token",
+            "/api/v1/jwt/token",
             json={
                 "node_id": "node-1",
                 # missing node_type and api_key
@@ -361,7 +361,7 @@ async def test_jwt_token_generation_cluster_authenticated(
     mock_cluster.tenant_id = "test-tenant"
 
     with patch(
-        "hub_api.modules.sase.api.jwt.asyncio.to_thread"
+        "hub_api.core.api.jwt.asyncio.to_thread"
     ) as mock_to_thread:
         mock_to_thread.return_value = mock_cluster
 
@@ -369,7 +369,7 @@ async def test_jwt_token_generation_cluster_authenticated(
             mock_flag.return_value = True
 
             response = await client.post(
-                "/api/v1/sase/jwt/token",
+                "/api/v1/jwt/token",
                 json={
                     "node_id": "cluster-1",
                     "node_type": "kubernetes_node",
@@ -399,7 +399,7 @@ async def test_jwt_token_generation_cluster_authentication_fails(
     client = app_with_sase.test_client()
 
     with patch(
-        "hub_api.modules.sase.api.jwt.asyncio.to_thread"
+        "hub_api.core.api.jwt.asyncio.to_thread"
     ) as mock_to_thread:
         mock_to_thread.return_value = None  # Authentication failed
 
@@ -407,7 +407,7 @@ async def test_jwt_token_generation_cluster_authentication_fails(
             mock_flag.return_value = True
 
             response = await client.post(
-                "/api/v1/sase/jwt/token",
+                "/api/v1/jwt/token",
                 json={
                     "node_id": "cluster-1",
                     "node_type": "kubernetes_node",
@@ -471,7 +471,7 @@ async def test_jwt_validate_token_success(
         mock_flag.return_value = True
 
         response = await client.post(
-            "/api/v1/sase/jwt/validate",
+            "/api/v1/jwt/validate",
             headers={"Authorization": f"Bearer {valid_token}"},
         )
 
@@ -496,7 +496,7 @@ async def test_jwt_validate_token_invalid(app_with_sase: Quart) -> None:
         mock_flag.return_value = True
 
         response = await client.post(
-            "/api/v1/sase/jwt/validate",
+            "/api/v1/jwt/validate",
             headers={"Authorization": "Bearer invalid-token-format"},
         )
 
@@ -528,7 +528,7 @@ async def test_jwt_refresh_token_success(app_with_sase: Quart) -> None:
         mock_flag.return_value = True
 
         response = await client.post(
-            "/api/v1/sase/jwt/refresh",
+            "/api/v1/jwt/refresh",
             json={"refresh_token": refresh_token},
         )
 
@@ -552,7 +552,7 @@ async def test_jwt_refresh_token_invalid(app_with_sase: Quart) -> None:
         mock_flag.return_value = True
 
         response = await client.post(
-            "/api/v1/sase/jwt/refresh",
+            "/api/v1/jwt/refresh",
             json={"refresh_token": "invalid-token"},
         )
 
@@ -889,7 +889,7 @@ async def test_jwt_revoke_requires_tenant(app_with_sase: Quart) -> None:
         mock_flag.return_value = True
 
         response = await client.post(
-            "/api/v1/sase/jwt/revoke",
+            "/api/v1/jwt/revoke",
             json={"node_id": "some-node"},
         )
 
@@ -920,7 +920,7 @@ async def test_jwt_revoke_requires_scope(app_with_sase: Quart) -> None:
         mock_flag.return_value = True
 
         response = await client.post(
-            "/api/v1/sase/jwt/revoke",
+            "/api/v1/jwt/revoke",
             json={"node_id": "some-node"},
             headers={"Authorization": f"Bearer {token_without_scope}"},
         )

--- a/hub_api/tests/test_sase_api_crypto.py
+++ b/hub_api/tests/test_sase_api_crypto.py
@@ -433,7 +433,7 @@ async def test_jwt_public_key_endpoint(app_with_sase: Quart) -> None:
     with patch("hub_api.entitlements.gate.feature_enabled") as mock_flag:
         mock_flag.return_value = True
 
-        response = await client.get("/api/v1/sase/jwt/public-key")
+        response = await client.get("/api/v1/jwt/public-key")
 
         assert response.status_code == 200
         data = await response.get_json()

--- a/hub_api/tests/test_sase_api_crypto.py
+++ b/hub_api/tests/test_sase_api_crypto.py
@@ -605,7 +605,7 @@ async def test_wireguard_keys_generation_cluster_success(
 
     mock_cluster = MagicMock()
     mock_cluster.id = "cluster-1"
-    mock_cluster.tenant_id = "test-tenant"
+    mock_cluster.tenant = "test-tenant"
 
     with patch(
         "hub_api.modules.sdwan.api.wireguard.asyncio.to_thread"

--- a/hub_api/tests/test_sase_context_auth.py
+++ b/hub_api/tests/test_sase_context_auth.py
@@ -1,0 +1,47 @@
+"""Tests for SASE context-based authentication evaluator."""
+from __future__ import annotations
+
+import pytest
+
+from hub_api.modules.sase.auth.context import ContextAuthEvaluator, ContextAuthDecision
+
+
+@pytest.mark.asyncio
+async def test_context_auth_evaluator_instantiates() -> None:
+    """Test that ContextAuthEvaluator can be instantiated.
+
+    Verifies the stub is wired and ready for future development.
+    """
+    evaluator = ContextAuthEvaluator()
+    assert evaluator is not None
+
+
+@pytest.mark.asyncio
+async def test_context_auth_evaluate_returns_decision() -> None:
+    """Test that evaluate returns a ContextAuthDecision.
+
+    Verifies the method signature and return type match the contract.
+    """
+    evaluator = ContextAuthEvaluator()
+    context = {"node_id": "test-node", "tenant": "default"}
+
+    decision = evaluator.evaluate(context)
+
+    assert isinstance(decision, ContextAuthDecision)
+    assert isinstance(decision.allowed, bool)
+    assert isinstance(decision.reason, str)
+
+
+@pytest.mark.asyncio
+async def test_context_auth_evaluate_safe_default() -> None:
+    """Test that evaluate returns allow=True by default (Phase-1 stub).
+
+    Phase-1 scaffold always allows; future phases will integrate threat intel.
+    """
+    evaluator = ContextAuthEvaluator()
+    context = {"node_id": "any-node", "tenant": "any-tenant"}
+
+    decision = evaluator.evaluate(context)
+
+    assert decision.allowed is True
+    assert "not_implemented" in decision.reason.lower()

--- a/hub_api/tests/test_sase_module.py
+++ b/hub_api/tests/test_sase_module.py
@@ -16,25 +16,23 @@ async def test_sase_module_returns_valid_contract() -> None:
     contract = sase_module()
 
     assert contract.name == "sase"
-    assert len(contract.blueprints) == 2  # certs and jwt only
-    assert len(contract.nav) == 0  # transport nav moved to sdwan
-    assert len(contract.flags) == 2  # certs and auth only
-    assert len(contract.entitlements) == 2  # certs and auth only
-    assert len(contract.migrations) == 3  # 0005, 0006, 0008 (user fields, per-tenant-unique, security tables)
+    assert len(contract.blueprints) == 0  # cert/jwt blueprints moved to core
+    assert len(contract.nav) == 1  # Security nav only
+    assert len(contract.flags) == 4  # threat_feeds, scanner, protection, context_auth
+    assert len(contract.entitlements) == 4  # threat_feeds, scanner, protection, context_auth
+    assert len(contract.migrations) == 2  # 0006, 0008 (per-tenant-unique, security tables)
     assert contract.health is None
 
-    # Verify blueprint names
+    # Verify no blueprints (moved to core)
     blueprint_names = {bp.name for bp in contract.blueprints}
-    expected_names = {
-        "sase_certs",
-        "sase_jwt",
-    }
-    assert blueprint_names == expected_names
+    assert len(blueprint_names) == 0
 
-    # Verify flags include SASE features (auth and certs only)
+    # Verify flags are security-focused (not certs/auth)
     expected_flags = {
-        "tobogganing.sase.certs",
-        "tobogganing.sase.auth",
+        "tobogganing.sase.threat_feeds",
+        "tobogganing.sase.scanner",
+        "tobogganing.sase.protection",
+        "tobogganing.sase.context_auth",
     }
     assert set(contract.flags) == expected_flags
 
@@ -52,11 +50,13 @@ async def test_sase_module_registered_in_app(app: Quart) -> None:
     # Verify by checking that we can get the contract from the registry
     flags = app.registry.declared_flags()
 
-    # Verify both ping and SASE module flags are present
+    # Verify both ping and SASE module flags are present (security-focused now)
     assert "tobogganing.ping.enabled" in flags
-    assert "tobogganing.sase.certs" in flags
-    assert "tobogganing.sase.auth" in flags
-    # Transport flags moved to sdwan
+    assert "tobogganing.sase.threat_feeds" in flags
+    assert "tobogganing.sase.scanner" in flags
+    assert "tobogganing.sase.protection" in flags
+    assert "tobogganing.sase.context_auth" in flags
+    # Transport flags (and cert/jwt auth) moved to sdwan/core respectively
     assert "tobogganing.sdwan.clusters" in flags
     assert "tobogganing.sdwan.clients" in flags
     assert "tobogganing.sdwan.status" in flags
@@ -70,6 +70,7 @@ async def test_sase_routes_registered_at_correct_urls() -> None:
 
     Verifies the URL map contains all expected SASE routes with proper paths.
     Creates a minimal app with SASE module and registry to verify routing.
+    Note: cert/jwt endpoints are now core-owned and served from /api/v1/{certs,jwt}
     """
     from unittest.mock import MagicMock
 
@@ -84,7 +85,7 @@ async def test_sase_routes_registered_at_correct_urls() -> None:
     mock_db = MagicMock()
     app.registry = ModuleRegistry()
 
-    # Register SASE module
+    # Register SASE module (now security-only, no cert/jwt blueprints)
     sase_contract = sase_module()
     app.registry.register(sase_contract)
 
@@ -95,18 +96,7 @@ async def test_sase_routes_registered_at_correct_urls() -> None:
     # Collect all registered routes from the app's URL map
     routes = {str(rule.rule) for rule in app.url_map.iter_rules()}
 
-    # Expected SASE routes (auth/certs only; transport moved to sdwan)
-    expected_routes = {
-        "/api/v1/sase/certs/certificates",  # POST
-        "/api/v1/sase/jwt/token",  # POST
-        "/api/v1/sase/jwt/refresh",  # POST
-        "/api/v1/sase/jwt/validate",  # POST
-        "/api/v1/sase/jwt/revoke",  # POST
-        "/api/v1/sase/jwt/public-key",  # GET
-    }
-
-    # Verify all expected routes exist
-    for expected_route in expected_routes:
-        assert (
-            expected_route in routes
-        ), f"Expected route {expected_route} not found in app routes.\nAvailable routes: {sorted(routes)}"
+    # SASE module no longer registers cert/jwt routes (moved to core)
+    # Verify no sase-prefixed cert/jwt routes exist
+    sase_routes = [r for r in routes if "/api/v1/sase" in r]
+    assert len(sase_routes) == 0, f"SASE should have no routes after Phase 4 reduction, found: {sase_routes}"


### PR DESCRIPTION
Final phase of the sase → core/sdwan/sase/ziti split.

- Moved cert/jwt HTTP blueprints `sase/api/{certs,jwt}.py` → `hub_api/core/api/` (blueprints `core_certs`/`core_jwt`), registered directly in `app.py` (always-on, like auth/portal/headend) at `/api/v1/{certs,jwt}`.
- Emptied sase's blueprint tuple; removed the `sase/web/` stub.
- Added `sase/auth/context.py` — `ContextAuthEvaluator` scaffold (threat-intel / impossible-travel / risk step-up; safe-allow default).
- Reduced sase contract: nav=[Security], flags `tobogganing.sase.{threat_feeds,scanner,protection,context_auth}`, migrations [0006,0008], blueprints=[].
- Reconciled with #87: fixed a mock-cluster `.tenant` attr in `test_sase_api_crypto` so the new wireguard identity binding is satisfied.

**Verified (rebased onto current release):** git-clean; all 3 module boundaries clean (sdwan/sase/ziti ⊥ siblings); app boots (23 routes; core certs/jwt mounted); collection **859/0 errors**; batches — sase/core/app/openapi/portal 242 pass, test_sase_api_crypto 23, sdwan 110.

Completes core ✅ · sdwan ✅ · sase ✅ · ziti ✅.

🤖 Generated with [Claude Code](https://claude.com/claude-code)