### PR TITLE
docs(auth): machine-JWT auth redesign (C+D) spec + plan

### DIFF
--- a/docs/superpowers/plans/2026-07-29-auth-redesign-cd.md
+++ b/docs/superpowers/plans/2026-07-29-auth-redesign-cd.md
@@ -1,0 +1,246 @@
+# Auth Redesign (C+D) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax. Executed by `penguin-python-dev` specialists — implement to PenguinTech Python conventions (Quart async, `@dataclass(slots=True)`, type hints, penguin-dal, structlog masked logging).
+
+**Goal:** Replace the machine/headend auth surface's global static tokens with per-cluster machine-JWTs (tenant+scope claims), add rotating single-use refresh with a Valkey `jti` revocation store, and scope every machine-plane query to the authenticated cluster's real tenant — closing findings C, D, and security-review Finding 2.
+
+**Architecture:** A new shared Valkey `CacheClient` (`hub_api/cache/`) backs the revocation store. `/auth/token` issues machine-JWTs; a `@require_machine_jwt` decorator protects the headend routes with a dual-accept flag (`tobogganing.core.machine_jwt_required`, default OFF) so the Go headend can migrate without a lockstep deploy. Refresh rotates single-use with subject re-check.
+
+**Tech Stack:** Quart, pyjwt (RS256 via `hub_api/crypto/keys.py` KeyProvider), redis-py (Valkey), penguin-dal, PostHog flags via `hub_api/flags`.
+
+## Global Constraints
+
+- Spec: `docs/superpowers/specs/2026-07-29-auth-redesign-cd-design.md` — authoritative.
+- Green gate (per phase): `python3 -m pytest hub_api/tests/` (baseline **859 tests**, 0 failures) — run in **targeted batches** (env kills runs >~120s); `python3 scripts/audit_imports.py` boundaries clean; `create_app()` boots. Clean stale bytecode first: `find hub_api -type d -name __pycache__ -exec rm -rf {} +`.
+- **Commit-completeness (hard):** after each commit, `git status --short` empty + `git show HEAD --stat` lists every touched file. `git check-ignore` every NEW file (the `.gitignore` `certs/` footgun is fixed but verify).
+- Flag `tobogganing.core.machine_jwt_required` — core tier, **free**, default **OFF** (dual-accept). No license entitlement.
+- Access-token TTL 1h; refresh TTL default 8h (≤24h). RS256. Never log raw tokens — mask (`tok_****1234`), log `sub`+tenant only.
+- No external API URL changes (`/auth/token`, `/auth/refresh`, `/auth/validate` keep paths).
+- Machine-JWT tenant = `cluster.tenant` (the dataclass field is `.tenant`, NOT `.tenant_id` — the recon-confirmed bug source).
+
+---
+
+## Task 1: Shared Valkey `CacheClient` foundation
+
+**Files:**
+- Create: `hub_api/cache/__init__.py` (exports `CacheClient`, `prefixed`, `NamespaceError`)
+- Create: `hub_api/cache/client.py`
+- Create: `hub_api/cache/keys.py`
+- Modify: `hub_api/app.py` (create + store `app.config["CACHE"]` in `create_app`)
+- Test: `hub_api/tests/test_cache_client.py`
+
+**Interfaces:**
+- Produces: `CacheClient(host,port,db,user,password)` with `async get(ns, *parts) -> str|None`, `async set(ns, *parts, value, ttl_seconds=None)`, `async delete(ns, *parts)`, `async exists(ns, *parts) -> bool`, all namespace-guarded; `.available -> bool`; a `fail_closed` param on read/set (default False → best-effort with in-memory fallback; True → raise `CacheUnavailable` on backend error, no fallback). `keys.prefixed(ns, *parts) -> str` → `"{ns}:{':'.join(parts)}"`. `keys.NAMESPACES = frozenset({"auth","sase:blocklist","sase:catcache","rl"})`.
+- Consumed by: Tasks 4 (revocation) uses `fail_closed=True` for `auth:*`.
+
+- [ ] **Step 1: Write failing tests** (`test_cache_client.py`) — key builder + namespace guard + fallback behavior:
+
+```python
+import pytest
+from hub_api.cache.keys import prefixed, NAMESPACES, NamespaceError
+from hub_api.cache.client import CacheClient, CacheUnavailable
+
+def test_prefixed_builds_namespaced_key():
+    assert prefixed("auth", "refresh", "cluster:1") == "auth:refresh:cluster:1"
+
+def test_prefixed_rejects_unknown_namespace():
+    with pytest.raises(NamespaceError):
+        prefixed("bogus", "x")
+
+@pytest.mark.asyncio
+async def test_set_get_roundtrip_or_fallback():
+    c = CacheClient(host="127.0.0.1", port=6399, db=0)  # unreachable port
+    # best-effort (default): set/get degrade to in-memory fallback, no raise
+    await c.set("rl", "k", value="v", ttl_seconds=5)
+    assert await c.get("rl", "k") == "v"
+
+@pytest.mark.asyncio
+async def test_fail_closed_raises_when_backend_down():
+    c = CacheClient(host="127.0.0.1", port=6399, db=0)
+    with pytest.raises(CacheUnavailable):
+        await c.get("auth", "x", fail_closed=True)
+```
+
+- [ ] **Step 2: Run → FAIL** (`pytest hub_api/tests/test_cache_client.py -v`) — module not found.
+- [ ] **Step 3: Implement** `keys.py` (`prefixed`, `NAMESPACES`, `NamespaceError`) and `client.py`. `CacheClient` wraps `redis.Redis(..., socket_timeout=0.05, socket_connect_timeout=0.05, health_check_interval=0, decode_responses=True)` via `asyncio.to_thread`; lazy-connect; on backend error → if `fail_closed` raise `CacheUnavailable`, else use a bounded `dict` fallback (cap ~10k keys, ignore TTL precision). Namespace guard: first arg must be in `NAMESPACES` else `NamespaceError`. 2-3 line docstrings.
+- [ ] **Step 4: Run → PASS.**
+- [ ] **Step 5: Wire in `app.py`** — in `create_app`, `app.config["CACHE"] = CacheClient(host=os.getenv("CACHE_HOST","localhost"), port=int(os.getenv("CACHE_PORT","6379")), db=int(os.getenv("CACHE_DB","0")), user=os.getenv("CACHE_USER"), password=os.getenv("CACHE_PASS"))`. Boot check: `create_app()` clean.
+- [ ] **Step 6: Green gate** (batch: `test_cache_client.py`, then a smoke `test_app.py`) + commit (`git add -A`; verify status clean + check-ignore new files).
+
+---
+
+## Task 2: Machine-JWT issuance + bug fixes C3/C4
+
+**Files:**
+- Modify: `hub_api/core/api/jwt.py` (the `/auth/token` cluster path: `.tenant` fix, `await` fix, add `jti`, scope claim)
+- Modify: `hub_api/api/headend_routes.py` (same `/auth/token` + `/auth/refresh` issuance sites: `:359-361,373,387-389,401,448-460`)
+- Create: `hub_api/auth/machine_claims.py` (a single helper building machine-JWT claims — DRY across the two issuance sites)
+- Test: `hub_api/tests/test_machine_jwt_issuance.py`
+
+**Interfaces:**
+- Produces: `build_machine_claims(sub_id, node_type, tenant, *, token_type="access") -> dict` returning `{"sub": f"cluster:{sub_id}", "iss":..., "aud":"headend", "tenant": tenant, "scope": "firewall:read wireguard:read ports:read metrics:write", "jti": <uuid4 hex>}` (+ `token_type="refresh"` when refresh). `iat`/`exp` added by the encoder. Uses `uuid.uuid4().hex` for jti (NOT Math.random / time-based).
+- Consumes: `hub_api.auth.jwt.encode_access_token`, `hub_api.crypto.keys` KeyProvider from `app.config["KEY_PROVIDER"]`.
+
+- [ ] **Step 1: Write failing tests** — tenant fix + await fix + jti:
+
+```python
+@pytest.mark.asyncio
+async def test_auth_token_cluster_uses_real_tenant(app_with_headend, cluster_stub):
+    # cluster_stub.tenant == "acme"; NOT tenant_id
+    resp = await client.post("/api/v1/auth/token", json={"node_id":"c1","node_type":"kubernetes_node","api_key":"k"})
+    assert resp.status_code == 200
+    claims = decode(resp.json["access_token"])
+    assert claims["tenant"] == "acme"        # regression C3 (was "default")
+    assert claims["sub"] == "cluster:c1"
+    assert "jti" in claims and "scope" in claims
+
+@pytest.mark.asyncio
+async def test_auth_token_binds_identity(app_with_headend, cluster_stub):
+    # cluster_stub.id == "c1"; requesting node_id "c1" succeeds (await path, regression C4)
+    resp = await client.post("/api/v1/auth/token", json={"node_id":"c1", ...})
+    assert resp.status_code == 200
+    # mismatched node_id rejected
+    resp2 = await client.post("/api/v1/auth/token", json={"node_id":"other", ...})
+    assert resp2.status_code == 401
+```
+
+- [ ] **Step 2: Run → FAIL** (C3: tenant is "default"; C4: even matching node_id → 401 due to un-awaited coroutine).
+- [ ] **Step 3: Implement** — create `build_machine_claims`; in both issuance sites replace `getattr(cluster,"tenant_id","default")` → `cluster.tenant`, and `await asyncio.to_thread(authenticate_cluster, api_key)` → `await authenticate_cluster(api_key)` (it's `async def`; the `to_thread` returned an un-awaited coroutine). Use `build_machine_claims` for access + refresh. Confirm `authenticate_client` path is called consistently.
+- [ ] **Step 4: Run → PASS.**
+- [ ] **Step 5: Green gate** (batch: new test + `test_jwt.py` + `test_sase_api_crypto.py` (jwt path) + `test_headend_policy_routes.py`) + commit.
+
+---
+
+## Task 3: `require_machine_jwt` + dual-accept flag + tenant scoping (C1/C2) + Finding 2 (C6)
+
+**Files:**
+- Modify: `hub_api/auth/middleware.py` (add `require_machine_jwt(*scopes)`; sets `g.machine_tenant`, `g.machine_sub`)
+- Modify: `hub_api/api/headend_routes.py` (`firewall/rules`, `wireguard/peers`, `headend/ports`: swap `_verify_headend_token` for `@require_machine_jwt`, scope queries to `g.machine_tenant`)
+- Modify: `hub_api/modules/sdwan/api/clients.py` (`submit_headend_metrics` :448 — replace `_verify_bootstrap_token` with `@require_machine_jwt("metrics:write")`)
+- Modify: `hub_api/core/api/certs.py` (cert issuance :59 — same swap)
+- Test: `hub_api/tests/test_machine_jwt_routes.py`
+
+**Interfaces:**
+- Consumes: `build_machine_claims` (T2), flag `tobogganing.core.machine_jwt_required` via `hub_api.flags.feature_enabled`, `decode_token`.
+- Produces: `g.machine_tenant: str`, `g.machine_sub: str` for handler tenant-scoping.
+
+- [ ] **Step 1: Write failing tests** — dual-accept + tenant scoping + Finding 2:
+
+```python
+async def test_dual_accept_flag_off_accepts_both(monkeypatch):
+    monkeypatch (flag OFF)
+    assert (await get("/api/v1/firewall/rules", static_token)).status_code == 200
+    assert (await get("/api/v1/firewall/rules", machine_jwt)).status_code == 200
+
+async def test_flag_on_rejects_static(monkeypatch):
+    monkeypatch (flag ON)
+    assert (await get("/api/v1/firewall/rules", static_token)).status_code == 401
+    assert (await get("/api/v1/firewall/rules", machine_jwt)).status_code == 200
+
+async def test_tenant_scoping(...):
+    # machine_jwt tenant=acme; firewall rules query scoped to acme, not "default"
+    resp = await get("/api/v1/firewall/rules", machine_jwt_acme)
+    assert all(r["tenant"]=="acme" for r in resp.json["rules"])   # regression C2
+
+async def test_finding2_metrics_requires_machine_jwt(monkeypatch):  # regression: security-review finding-2
+    monkeypatch (flag ON)
+    assert (await post("/api/v1/clients/headends/c1/metrics", bootstrap_token)).status_code == 401
+    assert (await post("/api/v1/clients/headends/c1/metrics", machine_jwt_metrics)).status_code == 200
+```
+
+- [ ] **Step 2: Run → FAIL** (decorator not defined; routes still use static/bootstrap).
+- [ ] **Step 3: Implement** `require_machine_jwt(*scopes)`: decode Bearer; if valid machine-JWT (`aud=="headend"`, scopes ⊆ token scope, not denylisted — denylist check is a T4 hook, no-op until T4) → set `g.machine_tenant=claims["tenant"]`, `g.machine_sub=claims["sub"]`; else if flag OFF → legacy `_verify_headend_token`/`_verify_bootstrap_token` and set `g.machine_tenant="default"`; else 401. Apply decorator to the 4 routes; replace every `tenant="default"` in those handlers with `g.machine_tenant`.
+- [ ] **Step 4: Run → PASS.**
+- [ ] **Step 5: Green gate** (batch: new test + `test_headend_policy_routes.py` + `test_sdwan_api_clients.py` + `test_sase_api_crypto.py` (certs) ) + commit.
+
+---
+
+## Task 4: Rotating refresh + revocation store (D1)
+
+**Files:**
+- Create: `hub_api/auth/refresh.py` (`rotate_refresh`, `revoke_cluster`, `is_jti_revoked`)
+- Modify: `hub_api/api/headend_routes.py` (`/auth/refresh` :496-592 → call `rotate_refresh`)
+- Modify: `hub_api/auth/middleware.py` (`require_machine_jwt` denylist check → call `is_jti_revoked`, fail-open on cache outage)
+- Test: `hub_api/tests/test_refresh_rotation.py`
+
+**Interfaces:**
+- Consumes: `app.config["CACHE"]` (T1) with `fail_closed=True` on refresh; `authenticate_cluster`; `build_machine_claims` (T2).
+- Produces: `async rotate_refresh(refresh_token, cache, key_provider) -> dict{access, refresh}` or raises `RefreshError(status, body)`; `async revoke_cluster(sub, cache)`; `async is_jti_revoked(jti, cache) -> bool` (fail-open).
+- Keys: `auth:refresh:<sub>` (current jti), `auth:revoked_jti:<jti>` (denylist).
+
+- [ ] **Step 1: Write failing tests** — rotation, replay, subject re-check, fail-closed:
+
+```python
+async def test_refresh_rotates_and_rejects_replay(cache):
+    r1 = await rotate_refresh(refresh0, cache, kp)          # ok, returns new refresh
+    with pytest.raises(RefreshError) as e:
+        await rotate_refresh(refresh0, cache, kp)           # replay old jti
+    assert e.value.status == 401                            # regression D1
+    # and the subject is now revoked
+    assert await is_jti_revoked(jti_of(r1["refresh"]), cache) or True
+
+async def test_refresh_rejects_inactive_cluster(cache, monkeypatch):
+    # authenticate by sub returns None → 401
+    with pytest.raises(RefreshError) as e:
+        await rotate_refresh(valid_refresh, cache, kp)
+    assert e.value.status == 401
+
+async def test_refresh_fail_closed_when_cache_down():
+    dead_cache = CacheClient(port=6399)
+    with pytest.raises(RefreshError) as e:
+        await rotate_refresh(valid_refresh, dead_cache, kp)
+    assert e.value.status == 503 and e.value.body.get("retry_with_credentials") is True
+```
+
+- [ ] **Step 2: Run → FAIL** (module absent; current refresh is non-rotating).
+- [ ] **Step 3: Implement** `rotate_refresh`: decode (must be `token_type=="refresh"`, unexpired) → on cache outage raise `RefreshError(503, {"retry_with_credentials": True})`; subject re-check via `authenticate` lookup by `sub` (inactive/absent → 401); compare presented `jti` to `cache.get("auth","refresh",sub, fail_closed=True)` — mismatch → `revoke_cluster(sub)` + 401; else mint new access+refresh, `cache.set("auth","refresh",sub, value=new_jti, ttl=refresh_ttl)`, return. `revoke_cluster` deletes `auth:refresh:<sub>` and denylists. `is_jti_revoked` checks `auth:revoked_jti:<jti>` fail-open. Wire `/auth/refresh` to it; wire the denylist hook in `require_machine_jwt`.
+- [ ] **Step 4: Run → PASS.**
+- [ ] **Step 5: Green gate** (batch: new test + `test_machine_jwt_routes.py` + `test_headend_policy_routes.py`) + commit.
+
+---
+
+## Task 5: `authenticate_cluster` rotation + hardening (C5)
+
+**Files:**
+- Modify: `hub_api/modules/sdwan/orchestrator/cluster_manager.py` (add `rotate_api_key`; document global-lookup rationale)
+- Test: `hub_api/tests/test_cluster_rotation.py`
+
+**Interfaces:**
+- Produces: `async rotate_api_key(cluster_id) -> str` (new raw key; stores new `sha256` hash; mirrors `ClientRegistry.rotate_api_key` at `client_registry.py:419`).
+
+- [ ] **Step 1: Write failing test:**
+
+```python
+async def test_cluster_rotate_api_key_invalidates_old(mgr, cluster):
+    old = "oldkey"; # registered
+    new = await mgr.rotate_api_key(cluster.id)
+    assert new != old
+    assert await mgr.authenticate_cluster(new) is not None
+    assert await mgr.authenticate_cluster(old) is None
+```
+
+- [ ] **Step 2: Run → FAIL** (no `rotate_api_key` on `ClusterManager`).
+- [ ] **Step 3: Implement** `rotate_api_key` mirroring `ClientRegistry.rotate_api_key`: `secrets.token_urlsafe(32)`, store `sha256().hexdigest()`, scoped to the manager's tenant; return raw key once. Add a docstring on `authenticate_cluster` explaining the global-by-hash lookup is intentional (pre-auth the caller has no tenant context; the issued JWT carries the real tenant).
+- [ ] **Step 4: Run → PASS.**
+- [ ] **Step 5: Green gate** (batch: new test + `test_sdwan_*.py`) + commit.
+
+---
+
+## Task 6: Go-coordination contract doc
+
+**Files:**
+- Create: `docs/architecture/headend-machine-jwt-contract.md`
+
+- [ ] **Step 1:** Document the Go-headend hand-off (spec §6): `CLUSTER_API_KEY` → `/auth/token` → machine-JWT; `Authorization: Bearer <access>` on all headend routes (replacing the `authToken`/`CLUSTER_API_KEY` split); store+rotate refresh; on `503 retry_with_credentials` re-auth. Note the flag stays OFF until Go ships. Commit.
+
+---
+
+## Self-Review
+
+- **Spec coverage:** C1→T3; C2→T3; C3→T2; C4→T2; C5→T5; C6→T3; D1→T4; shared Valkey→T1; flag→T3; Go contract→T6. All covered.
+- **Placeholders:** none — the denylist hook in T3 is explicitly a no-op-until-T4, not a TODO.
+- **Type consistency:** `g.machine_tenant`/`g.machine_sub`, `build_machine_claims`, `rotate_refresh`/`RefreshError`/`is_jti_revoked`, `CacheClient`/`prefixed`/`CacheUnavailable`, `rotate_api_key` — consistent across tasks.
+
+## Execution
+
+Sequential (2–5 depend on 1; 3 on 2; 4 on 1+2). Each task = its own branch off the prior (or off release once the prior merges) + PR + green gate + merge. Dispatch via `penguin-python-dev` in worktrees; verify commit-completeness + clean-bytecode + full-suite before each merge.

--- a/docs/superpowers/specs/2026-07-29-auth-redesign-cd-design.md
+++ b/docs/superpowers/specs/2026-07-29-auth-redesign-cd-design.md
@@ -1,0 +1,118 @@
+# Auth Redesign (Findings C + D) — Design Spec
+
+**Date**: 2026-07-29
+**Status**: Design approved; ready for implementation plan
+**Cross-references**:
+- Hub topology spec §8 #11 (headend-auth-redesign / finding C), #12 (refresh-rotation / finding D), §10 (enrollment model): `docs/superpowers/specs/2026-07-22-hub-topology-quart-brain-design.md`
+- Security review Finding 2 (`submit_headend_metrics` bootstrap token)
+
+## Goal
+
+Replace the machine/headend auth surface's global static tokens with **per-cluster machine-JWTs carrying tenant + scope claims**, add **rotating single-use refresh tokens with a `jti` revocation store**, and scope every machine-plane query to the authenticated cluster's real tenant. This closes the two production-gating security findings (C + D) and security-review Finding 2. It also introduces a **shared Valkey client** that the SASE security layer reuses.
+
+**Production gate**: findings C + D MUST land before the Quart brain serves production traffic.
+
+## Current-state problems (from recon)
+
+| # | Problem | Location |
+|---|---------|----------|
+| C1 | `firewall/rules`, `wireguard/peers`, `headend/ports` gated by one global static `HEADEND_API_TOKEN`, bypassing the OIDC tenant/scope model | `hub_api/api/headend_routes.py:147,209,747` |
+| C2 | Those queries hardcode `tenant="default"` — no per-tenant scoping | `headend_routes.py:160,220,754` |
+| C3 | Machine-JWT tenant read from nonexistent `cluster.tenant_id` attr → always `"default"` (the field is `.tenant`) | `headend_routes.py:373,401`; `core/api/jwt.py:115,143` |
+| C4 | `asyncio.to_thread(authenticate_cluster, …)` on an **async** function returns an un-awaited coroutine → identity check `getattr(cluster,"id")==node_id` can never pass on this path | `headend_routes.py:359-361,387-389` |
+| C5 | `authenticate_cluster` is a **global** hash lookup (not tenant-scoped) and has no rotation method | `sdwan/orchestrator/cluster_manager.py:108-164` |
+| C6 (Finding 2) | `submit_headend_metrics` authenticates with the shared `ENROLLMENT_BOOTSTRAP_TOKEN`; `cluster.id==headend_id` guard is tautological | `sdwan/api/clients.py:448-493` |
+| D1 | Refresh JWT is a non-rotating 24h token with no `jti`, no store, no revocation, no subject re-check → replayable; a revoked cluster keeps working | `headend_routes.py:496-592` |
+
+## Decisions (locked)
+
+1. **Mechanism**: per-cluster machine-JWT (spec §8 #11). SPIFFE/SPIRE remains the longer-term §8 #4 target — out of scope here.
+2. **Transition**: dual-accept behind flag `tobogganing.core.machine_jwt_required` (**default OFF = accept legacy static token OR machine-JWT**; flip **ON** = machine-JWT only). No lockstep deploy with the Go headend.
+3. **Revocation store**: **Valkey** (TTL-native, O(1)); the new shared client. **Fail-closed** on Valkey unavailability at refresh — the client falls back to re-authenticating with its `CLUSTER_API_KEY` (DB-backed, always available), so no hard outage.
+4. **Scope boundary**: machine/headend auth only. The DB-backed **user** refresh path (also non-rotating) is a documented follow-up, NOT in this slice.
+
+## Components
+
+### 1. Shared Valkey client — `hub_api/cache/`
+
+New package: a single async-friendly Valkey client the whole app shares, replacing the fragmented `redis.Redis(db=1)` / `db=2` instantiation.
+
+- `hub_api/cache/client.py`: `CacheClient` — config from env (`CACHE_HOST`, `CACHE_PORT`, `CACHE_USER`, `CACHE_PASS`, `CACHE_DB`), a connection pool, `async` get/set/delete/exists/expire wrappers over `redis.Redis` via `asyncio.to_thread` with a short socket timeout (mirror the live-test limiter: 10-50ms, health_check_interval=0), and a **first-failure short-circuit to a bounded in-memory fallback** for non-security caches.
+- `hub_api/cache/keys.py`: key-prefix helper enforcing per-service ACL namespaces. Canonical prefixes: `auth:*` (this slice), `sase:blocklist:*`, `sase:catcache:*` (future SASE), `rl:*` (rate-limit). A `prefixed(namespace, *parts)` builder; a `require_namespace` guard so a caller can only touch its declared prefix.
+- Wired once in `app.py` via `app.config["CACHE"]`, created at `create_app()`.
+- **Security-cache reads (revocation) do NOT use the in-memory fallback** — they fail-closed (see §3). The fallback is only for best-effort caches.
+- Migrating existing `protection/` + live-test consumers onto this client is a **noted follow-up**, not part of this slice (they keep working as-is).
+- Helm: recommend Valkey AOF persistence + a per-service ACL user with `~auth:*` key pattern for the brain.
+
+### 2. Machine-JWT issuance — `hub_api/core/api/jwt.py` + `headend_routes.py`
+
+`POST /api/v1/auth/token` (cluster/headend path): authenticate with `CLUSTER_API_KEY`, issue:
+- **Access JWT** (1h): `sub="cluster:<id>"`, `iss`, `aud="headend"`, `tenant=<cluster.tenant>` (FIX C3: read `.tenant`, not `.tenant_id`), `scope="firewall:read wireguard:read ports:read metrics:write"`, `iat`, `exp`, `jti`.
+- **Refresh JWT** (short, default 8h — configurable; ≤24h per standards): `token_type="refresh"`, `sub`, `tenant`, `aud`, `jti`, `exp`.
+- FIX C4: `await authenticate_cluster(...)` directly (it is async); remove the `asyncio.to_thread` wrapper on the coroutine. Bind `cluster.id==node_id` (the existing A-fix) — which now actually runs.
+- Scope set derives from cluster role/type; keep a single machine scope-bundle for now (`machine`) expanded to the resource scopes above.
+
+### 3. Rotating refresh + revocation — `hub_api/auth/refresh.py` (new) + Valkey
+
+`POST /api/v1/auth/refresh`:
+1. Decode refresh JWT (must be valid RS256, `token_type=="refresh"`, unexpired).
+2. **Subject re-check** (FIX D1): `authenticate`-lookup the cluster by `sub`; reject if it no longer exists or is inactive.
+3. **Single-use rotation**: Valkey key `auth:refresh:<sub>` holds the *current* valid refresh `jti`. If the presented `jti` != stored → **reject** (superseded/replayed) and revoke the whole subject (defence-in-depth: a replay implies compromise). On success, mint a new refresh JWT, `SET auth:refresh:<sub> = new_jti` (TTL = refresh exp), and return new access + refresh.
+4. **Revocation denylist**: `auth:revoked_jti:<jti>` (TTL = token remaining life). Checked on every refresh AND on access-token validation for `aud=headend` tokens. A `revoke_cluster(sub)` admin op deletes `auth:refresh:<sub>` and denylists outstanding jtis.
+5. **Fail-closed**: if Valkey is unreachable during a refresh, return `503` with `retry_with_credentials=true`; the client re-auths at `/auth/token` with its `CLUSTER_API_KEY`. Access-token validation (per-request) stays stateless EXCEPT an optional denylist check that fail-*opens* on Valkey outage for availability (access tokens are already short-lived; refresh is the control point). This asymmetry is deliberate: revocation is enforced hard at refresh (every ≤1h), soft at per-request validation.
+
+### 4. Route protection + dual-accept — `hub_api/auth/middleware.py`
+
+New decorator `@require_machine_jwt(*scopes)`:
+- Extract Bearer token. Try machine-JWT decode first: valid + `aud=="headend"` + required scopes present + not denylisted → set `g.machine_tenant`, `g.machine_sub`; proceed.
+- If not a valid machine-JWT AND flag `tobogganing.core.machine_jwt_required` is **OFF** → fall back to `_verify_headend_token`/`_verify_bootstrap_token` (legacy static token), set `g.machine_tenant="default"` (legacy).
+- If flag **ON** → legacy path disabled; static token → 401.
+- Applied to: `firewall/rules`, `wireguard/peers`, `headend/ports` (`headend_routes.py`), `submit_headend_metrics` (FIX C6 — replaces bootstrap), cert issuance (`core/api/certs.py`).
+- **Every query in these handlers is scoped to `g.machine_tenant`** (FIX C2), not `"default"`.
+
+### 5. `authenticate_cluster` hardening — `sdwan/orchestrator/cluster_manager.py`
+
+- Add `rotate_api_key(cluster_id)` (parity with `ClientRegistry.rotate_api_key`).
+- Keep the global-by-hash lookup (the key IS the identity), but the issued JWT now carries the cluster's real `.tenant`, so downstream scoping is correct even though the *lookup* is global. Document why the lookup stays global (bootstrap: the caller has no tenant context until authenticated).
+
+### 6. Go-headend coordination contract (documented; separate session)
+
+The Go headend must: (a) exchange its `CLUSTER_API_KEY` at `/auth/token` for a machine-JWT; (b) send `Authorization: Bearer <access-jwt>` on all headend routes (replacing the `authToken`/`CLUSTER_API_KEY` split — spec §8 #11); (c) store the rotated refresh token and refresh before access expiry; (d) on a `503 retry_with_credentials`, re-auth with `CLUSTER_API_KEY`. The flag stays OFF until the Go headend ships this.
+
+## Flags & entitlements
+
+- `tobogganing.core.machine_jwt_required` — core, **free** (security infra, not licensed). Default **OFF** (dual-accept). Flip ON post-Go-cutover.
+- No new license entitlement (auth is core).
+
+## Error handling
+
+- Invalid/expired machine-JWT → 401. Missing scope → 403. Tenant mismatch (token tenant ≠ resource tenant, once resources carry tenant) → 403.
+- Refresh with superseded jti → 401 + subject revoked. Refresh for inactive/absent cluster → 401. Valkey down at refresh → 503 `retry_with_credentials`.
+- All auth failures logged with masked token + `sub` + resolved tenant (never the raw token).
+
+## Testing
+
+- **Issuance**: `/auth/token` cluster path issues access+refresh with `tenant=<real>` (regression for C3), `jti` present; the `await` path binds `id==node_id` (regression for C4 — mock returns a real object, assert 200; previously the coroutine bug → 401).
+- **Dual-accept**: flag OFF → static token accepted AND machine-JWT accepted; flag ON → static token → 401, machine-JWT → 200.
+- **Tenant scoping**: a machine-JWT for tenant A cannot read tenant B's firewall rules/peers (cross-tenant → empty/403) (regression for C2).
+- **Refresh rotation**: refresh returns a new refresh jti; replaying the old jti → 401 + subject revoked (regression for D1); refresh for a deleted/inactive cluster → 401.
+- **Revocation**: `revoke_cluster` → subsequent refresh 401; denylisted access jti rejected at refresh.
+- **Fail-closed**: Valkey unreachable at refresh → 503 `retry_with_credentials`.
+- **Finding 2**: `submit_headend_metrics` with a bootstrap token (flag ON) → 401; with a valid `metrics:write` machine-JWT → 200 (regression: `# regression: security-review finding-2`).
+- **Cache client**: key-prefix guard rejects a cross-namespace write; in-memory fallback engages for best-effort caches but NOT for revocation reads.
+
+## Sequencing (for the plan)
+
+1. Shared Valkey client (`hub_api/cache/`) — foundation, no behavior change.
+2. Machine-JWT issuance + bug fixes C3/C4 (`/auth/token`, `core/api/jwt.py`).
+3. `require_machine_jwt` decorator + dual-accept flag + tenant scoping (C1/C2) on the 3 headend routes + Finding 2 (C6).
+4. Rotating refresh + revocation store (D1) on Valkey.
+5. `authenticate_cluster` rotation + hardening (C5).
+
+Each is a separate PR into the release branch; 2–5 depend on 1; 3 depends on 2; 4 depends on 1+2. The Go contract (§6) is documented, not implemented here.
+
+## Notes
+
+- No external API URL changes. `/auth/token`, `/auth/refresh`, `/auth/validate` keep their paths; response bodies gain `jti`/rotated refresh.
+- Backward compatible while the flag is OFF — the data plane keeps working on the static token until Go cuts over.
+- Follow-up (not this slice): unify/rotate the DB-backed user refresh path; migrate `protection/`+live-test onto the shared cache client.


### PR DESCRIPTION
Design spec + task-by-task implementation plan for the production-gating auth redesign (findings C+D + security-review Finding 2).

- Per-cluster machine-JWT replacing global HEADEND_API_TOKEN; dual-accept behind `tobogganing.core.machine_jwt_required` (default OFF).
- Rotating single-use refresh + Valkey `jti` revocation store; fail-closed → re-auth.
- Shared `hub_api/cache/` Valkey client (SASE reuses it).
- Bug fixes: `tenant_id`→`tenant` (C3), `to_thread`-on-coroutine (C4), Finding-2 bootstrap token (C6).
- Go-headend coordination documented as a contract (separate session).

6 sequenced tasks; each its own PR. Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)