### PR TITLE
fix(auth): machine-JWT issuance + tenant/await fixes (auth redesign T2, C3/C4)

### DIFF
--- a/hub_api/api/headend_routes.py
+++ b/hub_api/api/headend_routes.py
@@ -19,6 +19,7 @@ import structlog
 from quart import Blueprint, current_app, request
 
 from hub_api.auth.jwt import decode_token, encode_access_token
+from hub_api.auth.machine_claims import build_machine_claims
 from hub_api.auth.middleware import current_claims, require_scope, require_tenant
 from hub_api.core import UserManager, CertificateManager
 from hub_api.crypto.keys import KeyProvider
@@ -356,9 +357,7 @@ async def issue_auth_token() -> tuple[dict[str, Any], int]:
             # Authenticate cluster/headend nodes
             if cluster_manager:
                 try:
-                    cluster = await asyncio.to_thread(
-                        cluster_manager.authenticate_cluster, api_key
-                    )
+                    cluster = await cluster_manager.authenticate_cluster(api_key)
                     if cluster and getattr(cluster, "id", None) == node_id:
                         authenticated = True
                         authenticated_principal = cluster
@@ -370,7 +369,7 @@ async def issue_auth_token() -> tuple[dict[str, Any], int]:
                             "region": getattr(cluster, "region", "unknown"),
                             "datacenter": getattr(cluster, "datacenter", "unknown"),
                         }
-                        tenant_id = getattr(cluster, "tenant_id", "default")
+                        tenant_id = cluster.tenant
                 except Exception as e:
                     logger.error(
                         "cluster_authentication_failed",
@@ -384,9 +383,7 @@ async def issue_auth_token() -> tuple[dict[str, Any], int]:
             # Authenticate client nodes
             if client_registry:
                 try:
-                    client = await asyncio.to_thread(
-                        client_registry.authenticate_client, api_key
-                    )
+                    client = await client_registry.authenticate_client(api_key)
                     if client and getattr(client, "id", None) == node_id:
                         authenticated = True
                         authenticated_principal = client
@@ -398,7 +395,7 @@ async def issue_auth_token() -> tuple[dict[str, Any], int]:
                             "client_type": getattr(client, "type", "unknown"),
                             "cluster_id": getattr(client, "cluster_id", "unknown"),
                         }
-                        tenant_id = getattr(client, "tenant_id", "default")
+                        tenant_id = client.tenant
                 except Exception as e:
                     logger.error(
                         "client_authentication_failed",
@@ -424,16 +421,20 @@ async def issue_auth_token() -> tuple[dict[str, Any], int]:
         principal_id = getattr(
             authenticated_principal, "id", node_id
         )  # Fall back to node_id if no id attr
-        claims = {
-            "sub": principal_id,
-            "iss": "tobogganing",
-            "aud": "tobogganing",
-            "tenant": tenant_id,
-            "node_type": node_type,
-            "permissions": " ".join(permissions),
-            "scope": " ".join(permissions),
-            "metadata": metadata,
-        }
+
+        # Build machine JWT claims (includes jti, scope, tenant)
+        claims = build_machine_claims(
+            sub_id=principal_id,
+            node_type=node_type,
+            tenant=tenant_id,
+            iss="tobogganing",
+            aud="tobogganing",
+            token_type="access",
+        )
+        # Add node metadata (not part of standard machine-JWT)
+        claims["node_type"] = node_type
+        claims["permissions"] = " ".join(permissions)
+        claims["metadata"] = metadata
 
         # Generate access token (1 hour)
         try:
@@ -445,9 +446,19 @@ async def issue_auth_token() -> tuple[dict[str, Any], int]:
                 500,
             )
 
-        # Generate refresh token (24 hours)
-        refresh_claims = claims.copy()
-        refresh_claims["token_type"] = "refresh"
+        # Generate refresh token (24 hours) — rebuild from machine_claims with refresh type
+        refresh_claims = build_machine_claims(
+            sub_id=principal_id,
+            node_type=node_type,
+            tenant=tenant_id,
+            iss="tobogganing",
+            aud="tobogganing",
+            token_type="refresh",
+        )
+        # Add node metadata
+        refresh_claims["node_type"] = node_type
+        refresh_claims["permissions"] = " ".join(permissions)
+        refresh_claims["metadata"] = metadata
         try:
             refresh_token = await encode_access_token(
                 refresh_claims, key_provider, ttl_hours=24

--- a/hub_api/auth/machine_claims.py
+++ b/hub_api/auth/machine_claims.py
@@ -1,0 +1,46 @@
+"""Machine-JWT claim builder for cluster/client authentication."""
+
+from __future__ import annotations
+
+import uuid
+
+
+def build_machine_claims(
+    sub_id: str,
+    node_type: str,
+    tenant: str,
+    *,
+    iss: str,
+    aud: str = "headend",
+    token_type: str = "access",
+) -> dict:
+    """Build claims dict for machine-JWT (cluster or client node).
+
+    Constructs the standard claims for access and refresh tokens issued
+    to authenticated clusters or clients. Does NOT include iat/exp—the
+    encoder adds those based on TTL.
+
+    Args:
+        sub_id: Subject ID (cluster.id or client.id).
+        node_type: Node type (kubernetes_node, raw_compute, client_docker, etc.).
+        tenant: Tenant ID (from cluster.tenant or client.tenant).
+        iss: Issuer claim (e.g. "tobogganing").
+        aud: Audience claim, defaults to "headend".
+        token_type: Token type; "access" (default) or "refresh".
+
+    Returns:
+        Claims dict with sub, iss, aud, tenant, scope, jti, and optionally token_type.
+    """
+    claims = {
+        "sub": f"cluster:{sub_id}" if node_type in ("kubernetes_node", "raw_compute") else f"client:{sub_id}",
+        "iss": iss,
+        "aud": aud,
+        "tenant": tenant,
+        "scope": "firewall:read wireguard:read ports:read metrics:write",
+        "jti": uuid.uuid4().hex,
+    }
+
+    if token_type == "refresh":
+        claims["token_type"] = "refresh"
+
+    return claims

--- a/hub_api/core/api/jwt.py
+++ b/hub_api/core/api/jwt.py
@@ -10,6 +10,7 @@ import structlog
 from quart import Blueprint, request, current_app
 
 from hub_api.auth.jwt import decode_token, encode_access_token
+from hub_api.auth.machine_claims import build_machine_claims
 from hub_api.auth.middleware import current_claims, require_scope, require_tenant
 from hub_api.crypto.keys import KeyProvider
 from hub_api.entitlements.gate import require_feature
@@ -98,9 +99,7 @@ async def generate_jwt_token() -> tuple[dict[str, Any], int]:
             # Authenticate cluster/headend nodes
             if cluster_manager:
                 try:
-                    cluster = await asyncio.to_thread(
-                        cluster_manager.authenticate_cluster, api_key
-                    )
+                    cluster = await cluster_manager.authenticate_cluster(api_key)
                     if cluster and getattr(cluster, "id", None) == node_id:
                         authenticated = True
                         authenticated_principal = cluster
@@ -112,7 +111,7 @@ async def generate_jwt_token() -> tuple[dict[str, Any], int]:
                             "region": getattr(cluster, "region", "unknown"),
                             "datacenter": getattr(cluster, "datacenter", "unknown"),
                         }
-                        tenant_id = getattr(cluster, "tenant_id", "default")
+                        tenant_id = cluster.tenant
                 except Exception as e:
                     logger.error(
                         "cluster_authentication_failed",
@@ -126,9 +125,7 @@ async def generate_jwt_token() -> tuple[dict[str, Any], int]:
             # Authenticate client nodes
             if client_registry:
                 try:
-                    client = await asyncio.to_thread(
-                        client_registry.authenticate_client, api_key
-                    )
+                    client = await client_registry.authenticate_client(api_key)
                     if client and getattr(client, "id", None) == node_id:
                         authenticated = True
                         authenticated_principal = client
@@ -140,7 +137,7 @@ async def generate_jwt_token() -> tuple[dict[str, Any], int]:
                             "client_type": getattr(client, "type", "unknown"),
                             "cluster_id": getattr(client, "cluster_id", "unknown"),
                         }
-                        tenant_id = getattr(client, "tenant_id", "default")
+                        tenant_id = client.tenant
                 except Exception as e:
                     logger.error(
                         "client_authentication_failed",
@@ -166,16 +163,20 @@ async def generate_jwt_token() -> tuple[dict[str, Any], int]:
         principal_id = getattr(
             authenticated_principal, "id", node_id
         )  # Fall back to node_id if no id attr
-        claims = {
-            "sub": principal_id,
-            "iss": "tobogganing",
-            "aud": "tobogganing",
-            "tenant": tenant_id,
-            "node_type": node_type,
-            "permissions": " ".join(permissions),
-            "scope": " ".join(permissions),
-            "metadata": metadata,
-        }
+
+        # Build machine JWT claims (includes jti, scope, tenant)
+        claims = build_machine_claims(
+            sub_id=principal_id,
+            node_type=node_type,
+            tenant=tenant_id,
+            iss="tobogganing",
+            aud="tobogganing",
+            token_type="access",
+        )
+        # Add node metadata (not part of standard machine-JWT)
+        claims["node_type"] = node_type
+        claims["permissions"] = " ".join(permissions)
+        claims["metadata"] = metadata
 
         # Generate access token (1 hour default)
         try:
@@ -187,9 +188,19 @@ async def generate_jwt_token() -> tuple[dict[str, Any], int]:
                 500,
             )
 
-        # Generate refresh token (24 hours; Phase-2 uses JWT; Phase-3 will use DB)
-        refresh_claims = claims.copy()
-        refresh_claims["token_type"] = "refresh"
+        # Generate refresh token (24 hours) — rebuild from machine_claims with refresh type
+        refresh_claims = build_machine_claims(
+            sub_id=principal_id,
+            node_type=node_type,
+            tenant=tenant_id,
+            iss="tobogganing",
+            aud="tobogganing",
+            token_type="refresh",
+        )
+        # Add node metadata
+        refresh_claims["node_type"] = node_type
+        refresh_claims["permissions"] = " ".join(permissions)
+        refresh_claims["metadata"] = metadata
         try:
             refresh_token = await encode_access_token(
                 refresh_claims, key_provider, ttl_hours=24
@@ -456,17 +467,17 @@ async def revoke_jwt_token() -> tuple[dict[str, Any], int]:
         node_tenant = None
         if cluster_manager:
             try:
-                cluster = await asyncio.to_thread(cluster_manager.get_cluster, node_id)
+                cluster = await cluster_manager.get_cluster(node_id)
                 if cluster:
-                    node_tenant = getattr(cluster, "tenant_id", "default")
+                    node_tenant = cluster.tenant
             except Exception:
                 pass
 
         if not node_tenant and client_registry:
             try:
-                client = await asyncio.to_thread(client_registry.get_client, node_id)
+                client = await client_registry.get_client(node_id)
                 if client:
-                    node_tenant = getattr(client, "tenant_id", "default")
+                    node_tenant = client.tenant
             except Exception:
                 pass
 

--- a/hub_api/tests/test_headend_policy_routes.py
+++ b/hub_api/tests/test_headend_policy_routes.py
@@ -598,47 +598,44 @@ async def test_post_auth_token_cluster_identity_bound_correctly(
     mock_cluster_manager = MagicMock()
     app_with_sase.config["CLUSTER_MANAGER"] = mock_cluster_manager
 
-    # Mock successful cluster authentication
+    # Mock successful cluster authentication (AsyncMock, .tenant field not .tenant_id)
     mock_cluster = MagicMock(
         id="cluster-1",
         region="us-east-1",
         datacenter="dc1",
-        tenant_id="default",
+        tenant="default",
     )
-    mock_cluster_manager.authenticate_cluster = MagicMock(return_value=mock_cluster)
+    mock_cluster_manager.authenticate_cluster = AsyncMock(return_value=mock_cluster)
 
-    with patch("hub_api.api.headend_routes.asyncio.to_thread") as mock_thread:
-        mock_thread.return_value = mock_cluster
+    response = await client.post(
+        "/api/v1/auth/token",
+        json={
+            "node_id": "cluster-1",  # Matching authenticated cluster
+            "node_type": "kubernetes_node",
+            "api_key": "test-api-key",
+        },
+    )
 
-        response = await client.post(
-            "/api/v1/auth/token",
-            json={
-                "node_id": "cluster-1",  # Matching authenticated cluster
-                "node_type": "kubernetes_node",
-                "api_key": "test-api-key",
-            },
-        )
+    assert response.status_code == 200
+    data = await response.get_json()
+    assert "access_token" in data
 
-        assert response.status_code == 200
-        data = await response.get_json()
-        assert "access_token" in data
+    # Decode token to verify sub claim
+    import jwt as pyjwt
 
-        # Decode token to verify sub claim
-        import jwt as pyjwt
+    provider = app_with_sase.config["KEY_PROVIDER"]
+    token = data["access_token"]
+    decoded = pyjwt.decode(
+        token,
+        provider.public_pem,
+        algorithms=["RS256"],
+        options={"verify_aud": False},
+    )
 
-        provider = app_with_sase.config["KEY_PROVIDER"]
-        token = data["access_token"]
-        decoded = pyjwt.decode(
-            token,
-            provider.public_pem,
-            algorithms=["RS256"],
-            options={"verify_aud": False},
-        )
-
-        # Sub must be the authenticated cluster's id, not trusting request body
-        assert (
-            decoded["sub"] == "cluster-1"
-        ), f"Expected sub='cluster-1', got sub='{decoded['sub']}'"
+    # Sub must be prefixed for machine JWT: cluster:cluster-1
+    assert (
+        decoded["sub"] == "cluster:cluster-1"
+    ), f"Expected sub='cluster:cluster-1', got sub='{decoded['sub']}'"
 
 
 # Regression tests for Security Finding B: Client-supplied tenant on GET /headend/<id>/ports

--- a/hub_api/tests/test_machine_jwt_issuance.py
+++ b/hub_api/tests/test_machine_jwt_issuance.py
@@ -1,0 +1,276 @@
+"""Tests for machine-JWT issuance with tenant + identity binding (regression C3/C4)."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+from datetime import datetime, timezone
+
+import pytest
+import jwt as pyjwt
+from quart import Quart
+
+from hub_api.auth.jwt import decode_token
+from hub_api.crypto import InAppKeyProvider, generate_rsa_key_pair
+from hub_api.modules.sdwan.orchestrator.cluster_manager import Cluster
+
+
+@pytest.fixture
+def app_with_headend(app: Quart) -> Quart:
+    """Create a test app with headend routes and AsyncMock for cluster manager.
+
+    The app fixture from conftest.py already registers all blueprints via create_app().
+    We just need to configure the managers with AsyncMocks.
+
+    Args:
+        app: Base test app fixture (already has headend_bp registered).
+
+    Returns:
+        Quart app with KEY_PROVIDER and managers configured with AsyncMocks.
+    """
+    # Set up key provider for token generation
+    private_pem, public_pem = generate_rsa_key_pair()
+    provider = InAppKeyProvider(private_pem, public_pem)
+    app.config["KEY_PROVIDER"] = provider
+
+    # Mock cluster manager with AsyncMock for authenticate_cluster
+    cluster_manager = MagicMock()
+    cluster_manager.authenticate_cluster = AsyncMock()
+    client_registry = MagicMock()
+    client_registry.authenticate_client = AsyncMock()
+    app.config["CLUSTER_MANAGER"] = cluster_manager
+    app.config["CLIENT_REGISTRY"] = client_registry
+
+    return app
+
+
+@pytest.fixture
+def cluster_stub() -> Cluster:
+    """Provide a test cluster with real tenant field (not tenant_id).
+
+    Returns:
+        Cluster stub with id="c1", tenant="acme", status="active".
+    """
+    now = datetime.now(timezone.utc)
+    return Cluster(
+        id="c1",
+        name="test-cluster",
+        region="us-west-2",
+        datacenter="dc1",
+        headend_url="https://headend.example.com",
+        status="active",
+        last_heartbeat=now,
+        client_count=0,
+        tenant="acme",  # The real field is .tenant, not .tenant_id
+    )
+
+
+@pytest.mark.asyncio
+async def test_auth_token_cluster_uses_real_tenant(
+    app_with_headend: Quart, cluster_stub: Cluster
+) -> None:
+    """Test /auth/token returns access token with real tenant (regression C3).
+
+    The bug: code reads getattr(cluster, "tenant_id", "default") but field is .tenant
+    → machine JWTs always get tenant="default"
+
+    Fix: read cluster.tenant instead.
+
+    Args:
+        app_with_headend: Test app with key provider and cluster manager.
+        cluster_stub: Cluster fixture with tenant="acme".
+    """
+    client = app_with_headend.test_client()
+
+    # Mock authenticate_cluster to return cluster_stub
+    cluster_manager = app_with_headend.config["CLUSTER_MANAGER"]
+    cluster_manager.authenticate_cluster.return_value = cluster_stub
+
+    response = await client.post(
+        "/api/v1/auth/token",
+        json={"node_id": "c1", "node_type": "kubernetes_node", "api_key": "test-key"},
+    )
+
+    assert response.status_code == 200, f"Expected 200, got {response.status_code}"
+    data = await response.get_json()
+    assert "access_token" in data
+
+    # Decode the access token and check claims
+    key_provider = app_with_headend.config["KEY_PROVIDER"]
+    claims = decode_token(data["access_token"], key_provider)
+    assert claims is not None, "Failed to decode access token"
+
+    # Regression C3: tenant should be "acme", not "default"
+    assert claims["tenant"] == "acme", f"Expected tenant='acme', got {claims['tenant']}"
+    # Machine JWT sub is prefixed: cluster:c1 for cluster nodes
+    assert claims["sub"] == "cluster:c1", f"Expected sub='cluster:c1', got {claims['sub']}"
+    assert "jti" in claims, "Missing jti claim"
+    assert "scope" in claims, "Missing scope claim"
+
+
+@pytest.mark.asyncio
+async def test_auth_token_binds_identity_matching_node_id(
+    app_with_headend: Quart, cluster_stub: Cluster
+) -> None:
+    """Test /auth/token succeeds when node_id matches cluster.id (regression C4).
+
+    The bug: code does `await asyncio.to_thread(authenticate_cluster, api_key)`
+    but authenticate_cluster is async def, so to_thread() runs it in thread returning
+    an un-awaited coroutine → cluster is None → identity check fails
+
+    Fix: `await authenticate_cluster(api_key)` (drop to_thread wrapper).
+
+    Args:
+        app_with_headend: Test app with key provider and cluster manager.
+        cluster_stub: Cluster fixture with id="c1".
+    """
+    client = app_with_headend.test_client()
+
+    # Mock authenticate_cluster to return cluster_stub
+    cluster_manager = app_with_headend.config["CLUSTER_MANAGER"]
+    cluster_manager.authenticate_cluster.return_value = cluster_stub
+
+    # Matching node_id → 200
+    response = await client.post(
+        "/api/v1/auth/token",
+        json={"node_id": "c1", "node_type": "kubernetes_node", "api_key": "test-key"},
+    )
+
+    assert (
+        response.status_code == 200
+    ), f"Matching node_id failed: {response.status_code}"
+
+
+@pytest.mark.asyncio
+async def test_auth_token_rejects_mismatched_node_id(
+    app_with_headend: Quart, cluster_stub: Cluster
+) -> None:
+    """Test /auth/token fails when node_id doesn't match cluster.id.
+
+    This ensures the identity binding actually works (regression C4).
+
+    Args:
+        app_with_headend: Test app with key provider and cluster manager.
+        cluster_stub: Cluster fixture with id="c1".
+    """
+    client = app_with_headend.test_client()
+
+    # Mock authenticate_cluster to return cluster_stub
+    cluster_manager = app_with_headend.config["CLUSTER_MANAGER"]
+    cluster_manager.authenticate_cluster.return_value = cluster_stub
+
+    # Mismatched node_id → 401
+    response = await client.post(
+        "/api/v1/auth/token",
+        json={"node_id": "other-id", "node_type": "kubernetes_node", "api_key": "test-key"},
+    )
+
+    assert (
+        response.status_code == 401
+    ), f"Mismatched node_id should fail with 401, got {response.status_code}"
+    data = await response.get_json()
+    assert "error" in data
+
+
+@pytest.mark.asyncio
+async def test_revoke_cross_tenant_guard_same_tenant(
+    app_with_headend: Quart, cluster_stub: Cluster
+) -> None:
+    """Test revoke endpoint allows revocation within same tenant (regression C3/C4).
+
+    The bug: node_tenant was always "default" due to C3/C4 (no real tenant lookup).
+    Result: cross-tenant guard never worked; could revoke other tenants' nodes.
+
+    Fix: read cluster.tenant (C3) + await async get_cluster (C4) properly.
+    Now revoke within same tenant is allowed.
+
+    Args:
+        app_with_headend: Test app with key provider and managers.
+        cluster_stub: Cluster stub with tenant="acme".
+    """
+    from unittest.mock import patch
+
+    from hub_api.auth.jwt import encode_access_token
+
+    client = app_with_headend.test_client()
+
+    # Mock get_cluster to return cluster_stub with tenant="acme"
+    cluster_manager = app_with_headend.config["CLUSTER_MANAGER"]
+    cluster_manager.get_cluster = AsyncMock(return_value=cluster_stub)
+
+    # Create a valid JWT token with tenant="acme" (same as cluster_stub)
+    key_provider = app_with_headend.config["KEY_PROVIDER"]
+    claims = {
+        "sub": "user-1",
+        "iss": "tobogganing",
+        "aud": "tobogganing",
+        "tenant": "acme",
+        "scope": "jwt:revoke",
+    }
+    token = await encode_access_token(claims, key_provider, ttl_hours=1)
+
+    # Mock feature flag to allow jwt feature
+    with patch("hub_api.entitlements.gate.feature_enabled") as mock_flag:
+        mock_flag.return_value = True
+
+        # POST /api/v1/jwt/revoke with matching tenant → 200
+        response = await client.post(
+            "/api/v1/jwt/revoke",
+            json={"node_id": "c1"},
+            headers={"Authorization": f"Bearer {token}"},
+        )
+
+    assert response.status_code == 200, f"Revoke same tenant failed: {response.status_code}"
+    data = await response.get_json()
+    assert data["revoked"] is True
+
+
+@pytest.mark.asyncio
+async def test_revoke_cross_tenant_guard_different_tenant(
+    app_with_headend: Quart, cluster_stub: Cluster
+) -> None:
+    """Test revoke endpoint blocks cross-tenant revocation (regression C3/C4).
+
+    Caller has tenant="other"; target cluster has tenant="acme".
+    Should be rejected with 403 (cross-tenant guard working correctly).
+
+    Args:
+        app_with_headend: Test app with key provider and managers.
+        cluster_stub: Cluster stub with tenant="acme".
+    """
+    from unittest.mock import patch
+
+    from hub_api.auth.jwt import encode_access_token
+
+    client = app_with_headend.test_client()
+
+    # Mock get_cluster to return cluster_stub with tenant="acme"
+    cluster_manager = app_with_headend.config["CLUSTER_MANAGER"]
+    cluster_manager.get_cluster = AsyncMock(return_value=cluster_stub)
+
+    # Create a valid JWT token with tenant="other" (different from cluster_stub)
+    key_provider = app_with_headend.config["KEY_PROVIDER"]
+    claims = {
+        "sub": "user-2",
+        "iss": "tobogganing",
+        "aud": "tobogganing",
+        "tenant": "other",
+        "scope": "jwt:revoke",
+    }
+    token = await encode_access_token(claims, key_provider, ttl_hours=1)
+
+    # Mock feature flag to allow jwt feature
+    with patch("hub_api.entitlements.gate.feature_enabled") as mock_flag:
+        mock_flag.return_value = True
+
+        # POST /api/v1/jwt/revoke with mismatched tenant → 403
+        response = await client.post(
+            "/api/v1/jwt/revoke",
+            json={"node_id": "c1"},
+            headers={"Authorization": f"Bearer {token}"},
+        )
+
+    assert (
+        response.status_code == 403
+    ), f"Cross-tenant revoke should be 403, got {response.status_code}"
+    data = await response.get_json()
+    assert "Forbidden" in data["error"]

--- a/hub_api/tests/test_sase_api_crypto.py
+++ b/hub_api/tests/test_sase_api_crypto.py
@@ -358,32 +358,31 @@ async def test_jwt_token_generation_cluster_authenticated(
     mock_cluster.id = "cluster-1"
     mock_cluster.region = "us-west"
     mock_cluster.datacenter = "us-west-1a"
-    mock_cluster.tenant_id = "test-tenant"
+    mock_cluster.tenant = "test-tenant"  # Field is .tenant, not .tenant_id
 
-    with patch(
-        "hub_api.core.api.jwt.asyncio.to_thread"
-    ) as mock_to_thread:
-        mock_to_thread.return_value = mock_cluster
+    # Mock cluster_manager.authenticate_cluster as async
+    cluster_manager = app_with_sase.config["CLUSTER_MANAGER"]
+    cluster_manager.authenticate_cluster = AsyncMock(return_value=mock_cluster)
 
-        with patch("hub_api.entitlements.gate.feature_enabled") as mock_flag:
-            mock_flag.return_value = True
+    with patch("hub_api.entitlements.gate.feature_enabled") as mock_flag:
+        mock_flag.return_value = True
 
-            response = await client.post(
-                "/api/v1/jwt/token",
-                json={
-                    "node_id": "cluster-1",
-                    "node_type": "kubernetes_node",
-                    "api_key": "secret-key",
-                },
-                headers={"Authorization": f"Bearer {valid_tenant_token}"},
-            )
+        response = await client.post(
+            "/api/v1/jwt/token",
+            json={
+                "node_id": "cluster-1",
+                "node_type": "kubernetes_node",
+                "api_key": "secret-key",
+            },
+            headers={"Authorization": f"Bearer {valid_tenant_token}"},
+        )
 
-            assert response.status_code == 200
-            data = await response.get_json()
-            assert "access_token" in data
-            assert "refresh_token" in data
-            assert data["expires_in"] == 3600
-            assert data["token_type"] == "Bearer"
+        assert response.status_code == 200
+        data = await response.get_json()
+        assert "access_token" in data
+        assert "refresh_token" in data
+        assert data["expires_in"] == 3600
+        assert data["token_type"] == "Bearer"
 
 
 @pytest.mark.asyncio
@@ -398,27 +397,26 @@ async def test_jwt_token_generation_cluster_authentication_fails(
     """
     client = app_with_sase.test_client()
 
-    with patch(
-        "hub_api.core.api.jwt.asyncio.to_thread"
-    ) as mock_to_thread:
-        mock_to_thread.return_value = None  # Authentication failed
+    # Mock cluster_manager.authenticate_cluster as async returning None
+    cluster_manager = app_with_sase.config["CLUSTER_MANAGER"]
+    cluster_manager.authenticate_cluster = AsyncMock(return_value=None)
 
-        with patch("hub_api.entitlements.gate.feature_enabled") as mock_flag:
-            mock_flag.return_value = True
+    with patch("hub_api.entitlements.gate.feature_enabled") as mock_flag:
+        mock_flag.return_value = True
 
-            response = await client.post(
-                "/api/v1/jwt/token",
-                json={
-                    "node_id": "cluster-1",
-                    "node_type": "kubernetes_node",
-                    "api_key": "invalid-key",
-                },
-                headers={"Authorization": f"Bearer {valid_tenant_token}"},
-            )
+        response = await client.post(
+            "/api/v1/jwt/token",
+            json={
+                "node_id": "cluster-1",
+                "node_type": "kubernetes_node",
+                "api_key": "invalid-key",
+            },
+            headers={"Authorization": f"Bearer {valid_tenant_token}"},
+        )
 
-            assert response.status_code == 401
-            data = await response.get_json()
-            assert "Authentication failed" in data["error"]
+        assert response.status_code == 401
+        data = await response.get_json()
+        assert "Authentication failed" in data["error"]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Task 2 of the auth-redesign plan.

- `build_machine_claims()` helper (sub, aud=headend, tenant, scope, jti) for the /auth/token access+refresh claims.
- **C3 fix**: issuance + the token-revoke handler read `cluster.tenant`/`client.tenant` (was `getattr(...,"tenant_id","default")` → always "default"). The revoke path's cross-tenant guard was broken by this — now correct.
- **C4 fix**: `await authenticate_cluster()/get_cluster()` (was `asyncio.to_thread()` on async fns → un-awaited coroutine → identity/tenant checks couldn't pass).
- Regression tests: tenant=real (C3), node_id bind 200/401 (C4), revoke same-tenant allowed / cross-tenant 403.

Verified: grep-clean (no tenant_id/to_thread-on-async remain); 62 jwt/auth tests pass; boot OK; collect 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)