### PR TITLE
feat(auth): require_machine_jwt + dual-accept + tenant scoping + least-privilege (auth redesign T3, C1/C2/C6)

### DIFF
--- a/hub_api/api/headend_routes.py
+++ b/hub_api/api/headend_routes.py
@@ -16,11 +16,16 @@ from datetime import datetime, timezone
 from typing import Any
 
 import structlog
-from quart import Blueprint, current_app, request
+from quart import Blueprint, current_app, g, request
 
 from hub_api.auth.jwt import decode_token, encode_access_token
 from hub_api.auth.machine_claims import build_machine_claims
-from hub_api.auth.middleware import current_claims, require_scope, require_tenant
+from hub_api.auth.middleware import (
+    current_claims,
+    require_machine_jwt,
+    require_scope,
+    require_tenant,
+)
 from hub_api.core import UserManager, CertificateManager
 from hub_api.crypto.keys import KeyProvider
 from hub_api.db import get_db
@@ -131,11 +136,12 @@ def get_certificate_manager(
 
 
 @headend_bp.route("/firewall/rules", methods=["GET"])
+@require_machine_jwt("firewall:read")
 async def get_firewall_rules() -> tuple[dict[str, Any], int]:
     """Get all firewall rules for headend consumption.
 
-    Requires headend authentication via Bearer token (HEADEND_API_TOKEN).
-    Returns rules for all active users in the default tenant.
+    Requires machine-JWT authentication (or legacy static token if flag OFF).
+    Returns rules for all active users in the authenticated tenant.
 
     Returns:
         - 200: {timestamp, rules_count, user_rules: {user_id: [rules]}}
@@ -143,11 +149,6 @@ async def get_firewall_rules() -> tuple[dict[str, Any], int]:
         - 500: {error: "..."} on server error
     """
     try:
-        # Authenticate headend
-        token = _extract_bearer_token()
-        if not _verify_headend_token(token):
-            return {"error": "Unauthorized: invalid headend token"}, 401
-
         db = get_db()
         if db is None:
             return {"error": "Database unavailable"}, 500
@@ -156,11 +157,10 @@ async def get_firewall_rules() -> tuple[dict[str, Any], int]:
         acm = get_access_control_manager(db)
         um = get_user_manager(db)
 
-        # Note: In a true multi-tenant setup, iterate all tenant configs
-        # For now, use default tenant (headend clients can provide via env)
-        tenant = "default"
+        # Use authenticated tenant from machine-JWT
+        tenant = g.machine_tenant
 
-        # Get all active users in the default tenant
+        # Get all active users in the authenticated tenant
         users = await um.list_users(tenant)
         all_rules: dict[str, Any] = {}
 
@@ -193,11 +193,12 @@ async def get_firewall_rules() -> tuple[dict[str, Any], int]:
 
 
 @headend_bp.route("/wireguard/peers", methods=["GET"])
+@require_machine_jwt("wireguard:read")
 async def get_wireguard_peers() -> tuple[dict[str, Any], int]:
     """Get all WireGuard peer configurations for headend consumption.
 
-    Requires headend authentication via Bearer token (HEADEND_API_TOKEN).
-    Returns peer configurations for the default tenant.
+    Requires machine-JWT authentication (or legacy static token if flag OFF).
+    Returns peer configurations for the authenticated tenant.
 
     Returns:
         - 200: {peers: [...], total: N, meta: {...}}
@@ -205,20 +206,14 @@ async def get_wireguard_peers() -> tuple[dict[str, Any], int]:
         - 500: {error: "..."} on server error
     """
     try:
-        # Authenticate headend
-        token = _extract_bearer_token()
-        if not _verify_headend_token(token):
-            return {"error": "Unauthorized: invalid headend token"}, 401
-
         # Get certificate manager from app config
         cert_manager: CertificateManager | None = current_app.config.get("CERT_MANAGER")
         if not cert_manager:
             logger.error("cert_manager_not_configured")
             return {"error": "Internal server error"}, 500
 
-        # Get all WireGuard peers for default tenant
-        # (headend operates at the cluster level, not tenant-scoped)
-        tenant = "default"
+        # Get all WireGuard peers for authenticated tenant
+        tenant = g.machine_tenant
         try:
             peers = await cert_manager.get_all_wireguard_peers(tenant_id=tenant)
         except Exception as e:
@@ -737,10 +732,11 @@ async def validate_auth_token() -> tuple[dict[str, Any], int]:
 
 
 @headend_bp.route("/headend/<headend_id>/ports", methods=["GET"])
+@require_machine_jwt("ports:read")
 async def get_headend_ports(headend_id: str) -> tuple[dict[str, Any], int]:
     """Get port configuration for a specific headend.
 
-    Requires headend authentication via Bearer token (HEADEND_API_TOKEN).
+    Requires machine-JWT authentication (or legacy static token if flag OFF).
     Optional query param: cluster_id (defaults to "cluster-{headend_id}").
 
     Args:
@@ -753,18 +749,12 @@ async def get_headend_ports(headend_id: str) -> tuple[dict[str, Any], int]:
         - 500: {error: "..."} on server error
     """
     try:
-        # Authenticate headend
-        token = _extract_bearer_token()
-        if not _verify_headend_token(token):
-            return {"error": "Unauthorized: invalid headend token"}, 401
-
         db = get_db()
         if db is None:
             return {"error": "Database unavailable"}, 500
 
-        # Get cluster from query params; tenant is always "default" (no client control)
-        # TODO(P-B §11): derive tenant from per-cluster machine-JWT
-        tenant = "default"
+        # Use authenticated tenant from machine-JWT
+        tenant = g.machine_tenant
         cluster_id = request.args.get("cluster_id", f"cluster-{headend_id}")
 
         pcm = get_port_config_manager(db)

--- a/hub_api/auth/machine_claims.py
+++ b/hub_api/auth/machine_claims.py
@@ -4,6 +4,10 @@ from __future__ import annotations
 
 import uuid
 
+# Scope sets by node type (least privilege)
+CLUSTER_SCOPES = "firewall:read wireguard:read ports:read metrics:write certs:issue"
+CLIENT_SCOPES = "wireguard:read"
+
 
 def build_machine_claims(
     sub_id: str,
@@ -18,11 +22,12 @@ def build_machine_claims(
 
     Constructs the standard claims for access and refresh tokens issued
     to authenticated clusters or clients. Does NOT include iat/exp—the
-    encoder adds those based on TTL.
+    encoder adds those based on TTL. Scopes are derived from node_type:
+    clusters get full access; clients get wireguard:read only (least privilege).
 
     Args:
         sub_id: Subject ID (cluster.id or client.id).
-        node_type: Node type (kubernetes_node, raw_compute, client_docker, etc.).
+        node_type: Node type (kubernetes_node, raw_compute, headend, client_docker, client_native).
         tenant: Tenant ID (from cluster.tenant or client.tenant).
         iss: Issuer claim (e.g. "tobogganing").
         aud: Audience claim, defaults to "headend".
@@ -31,12 +36,15 @@ def build_machine_claims(
     Returns:
         Claims dict with sub, iss, aud, tenant, scope, jti, and optionally token_type.
     """
+    is_cluster = node_type in ("kubernetes_node", "raw_compute", "headend")
+    scope = CLUSTER_SCOPES if is_cluster else CLIENT_SCOPES
+
     claims = {
-        "sub": f"cluster:{sub_id}" if node_type in ("kubernetes_node", "raw_compute") else f"client:{sub_id}",
+        "sub": f"cluster:{sub_id}" if is_cluster else f"client:{sub_id}",
         "iss": iss,
         "aud": aud,
         "tenant": tenant,
-        "scope": "firewall:read wireguard:read ports:read metrics:write certs:issue",
+        "scope": scope,
         "jti": uuid.uuid4().hex,
     }
 

--- a/hub_api/auth/machine_claims.py
+++ b/hub_api/auth/machine_claims.py
@@ -36,7 +36,7 @@ def build_machine_claims(
         "iss": iss,
         "aud": aud,
         "tenant": tenant,
-        "scope": "firewall:read wireguard:read ports:read metrics:write",
+        "scope": "firewall:read wireguard:read ports:read metrics:write certs:issue",
         "jti": uuid.uuid4().hex,
     }
 

--- a/hub_api/auth/middleware.py
+++ b/hub_api/auth/middleware.py
@@ -2,11 +2,14 @@
 
 Supports both Bearer/JWT (via @require_scope, @require_tenant) and session cookie
 (via @require_session_user, @require_role, @require_permission) authentication paths.
+Also provides machine-JWT authentication for cluster/headend routes.
 """
 
 from __future__ import annotations
 
 import functools
+import hmac
+import os
 from datetime import datetime
 from typing import Any, Callable, Optional
 
@@ -14,6 +17,7 @@ import structlog
 from quart import current_app, g, jsonify, request, Response
 
 from hub_api.auth.jwt import decode_token
+from hub_api.flags import feature_enabled
 
 logger = structlog.get_logger()
 
@@ -445,6 +449,165 @@ def require_admin(func: Callable[..., Any]) -> Callable[..., Any]:
         return jsonify({"error": "Forbidden: admin role required"}), 403
 
     return wrapper
+
+
+def _verify_headend_token(token: str | None) -> bool:
+    """Verify headend API token using constant-time comparison.
+
+    Args:
+        token: The Bearer token to verify.
+
+    Returns:
+        True if token matches HEADEND_API_TOKEN, False otherwise.
+    """
+    expected = os.getenv("HEADEND_API_TOKEN", "")
+    if not expected or not token:
+        return False
+    return hmac.compare_digest(token, expected)
+
+
+def _verify_bootstrap_token(token: str | None) -> bool:
+    """Verify bootstrap token using constant-time comparison.
+
+    Args:
+        token: The token to verify.
+
+    Returns:
+        True if token matches ENROLLMENT_BOOTSTRAP_TOKEN, False otherwise.
+    """
+    expected = os.getenv("ENROLLMENT_BOOTSTRAP_TOKEN", "")
+    if not expected or not token:
+        return False
+    return hmac.compare_digest(token, expected)
+
+
+async def _extract_machine_identity(
+    token: str,
+    *required_scopes: str,
+) -> tuple[dict[str, Any] | None, str | None]:
+    """Extract and validate machine-JWT identity.
+
+    Decodes the token, checks aud=="headend" and required scopes.
+    T4 denylist hook: check jti revocation status (not implemented yet).
+
+    Args:
+        token: Bearer token to decode.
+        required_scopes: Required scopes (space-separated string expected in token).
+
+    Returns:
+        Tuple of (claims, error_message) if valid, (None, error_msg) otherwise.
+    """
+    key_provider = current_app.config.get("KEY_PROVIDER")
+    if not key_provider:
+        return None, "key_provider_not_configured"
+
+    claims = decode_token(token, key_provider)
+    if not claims:
+        return None, "invalid_or_expired_token"
+
+    # Machine-JWT must have aud=="headend"
+    if claims.get("aud") != "headend":
+        return None, "invalid_audience"
+
+    # Check required scopes
+    token_scope_str = claims.get("scope", "")
+    if not token_scope_str:
+        return None, "missing_scopes"
+
+    token_scopes = set(token_scope_str.split())
+
+    for required in required_scopes:
+        if not _scope_satisfied(required, token_scopes):
+            return None, f"insufficient_scope:{required}"
+
+    # T4: Check denylist (jti revocation) — no-op until T4
+    # Hook: if await is_jti_revoked(claims.get("jti"), cache) then return None, "revoked"
+    # For now, skip (# T4 denylist hook)
+
+    return claims, None
+
+
+def require_machine_jwt(*required_scopes: str) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
+    """Decorator to require machine-JWT with specific scopes.
+
+    Supports dual-accept: when flag `tobogganing.core.machine_jwt_required` is OFF,
+    accepts either a valid machine-JWT OR legacy static tokens (headend/bootstrap).
+    When flag is ON, requires machine-JWT only.
+
+    Sets g.machine_tenant and g.machine_sub on success.
+
+    Args:
+        required_scopes: Scopes required in the machine-JWT (e.g., "firewall:read").
+
+    Returns:
+        Decorator function.
+    """
+
+    def decorator(func: Callable[..., Any]) -> Callable[..., Any]:
+        @functools.wraps(func)
+        async def wrapper(*args: Any, **kwargs: Any) -> Any:
+            # Extract Bearer token
+            auth_header = request.headers.get("Authorization", "")
+            if not auth_header.startswith("Bearer "):
+                return jsonify({"error": "Unauthorized: invalid authorization header"}), 401
+
+            token = auth_header[7:].strip()
+            if not token:
+                return jsonify({"error": "Unauthorized: missing token"}), 401
+
+            # Try machine-JWT first
+            claims, error = await _extract_machine_identity(token, *required_scopes)
+            if claims:
+                # Valid machine-JWT: set context and proceed
+                g.machine_tenant = claims.get("tenant")
+                g.machine_sub = claims.get("sub")
+                logger.info(
+                    "machine_jwt_authenticated",
+                    sub=g.machine_sub,
+                    tenant=g.machine_tenant,
+                    scopes=required_scopes,
+                )
+                return await func(*args, **kwargs)
+
+            # Machine-JWT failed; check flag for legacy fallback
+            flag_on = feature_enabled("tobogganing.core", "machine_jwt_required")
+
+            if not flag_on:
+                # Dual-accept: try legacy static tokens
+                if _verify_headend_token(token) or _verify_bootstrap_token(token):
+                    # Legacy static token accepted
+                    g.machine_tenant = "default"
+                    g.machine_sub = "legacy"
+                    logger.info(
+                        "legacy_token_authenticated",
+                        tenant=g.machine_tenant,
+                        scopes=required_scopes,
+                    )
+                    return await func(*args, **kwargs)
+                # No valid auth
+                logger.warning(
+                    "machine_jwt_auth_failed_flag_off",
+                    error=error,
+                    scopes=required_scopes,
+                )
+                return jsonify({"error": "Unauthorized: invalid token"}), 401
+            else:
+                # Flag ON: machine-JWT required, legacy disabled
+                logger.warning(
+                    "machine_jwt_required_flag_on",
+                    error=error,
+                    scopes=required_scopes,
+                )
+                return (
+                    jsonify(
+                        {"error": "Unauthorized: machine-JWT required"}
+                    ),
+                    401,
+                )
+
+        return wrapper
+
+    return decorator
 
 
 def set_session_cookie(

--- a/hub_api/auth/middleware.py
+++ b/hub_api/auth/middleware.py
@@ -481,6 +481,13 @@ def _verify_bootstrap_token(token: str | None) -> bool:
     return hmac.compare_digest(token, expected)
 
 
+# Per-token scope allowlists for legacy tokens (least privilege enforcement)
+HEADEND_TOKEN_SCOPES = frozenset(
+    {"firewall:read", "wireguard:read", "ports:read", "metrics:write"}
+)
+BOOTSTRAP_TOKEN_SCOPES = frozenset({"certs:issue"})
+
+
 async def _extract_machine_identity(
     token: str,
     *required_scopes: str,
@@ -573,24 +580,45 @@ def require_machine_jwt(*required_scopes: str) -> Callable[[Callable[..., Any]],
             flag_on = feature_enabled("tobogganing.core", "machine_jwt_required")
 
             if not flag_on:
-                # Dual-accept: try legacy static tokens
-                if _verify_headend_token(token) or _verify_bootstrap_token(token):
-                    # Legacy static token accepted
-                    g.machine_tenant = "default"
-                    g.machine_sub = "legacy"
-                    logger.info(
-                        "legacy_token_authenticated",
-                        tenant=g.machine_tenant,
+                # Dual-accept: try legacy static tokens with per-token allowlists
+                allowed_scopes = None
+                if _verify_headend_token(token):
+                    allowed_scopes = HEADEND_TOKEN_SCOPES
+                elif _verify_bootstrap_token(token):
+                    allowed_scopes = BOOTSTRAP_TOKEN_SCOPES
+                else:
+                    # No valid legacy token
+                    logger.warning(
+                        "machine_jwt_auth_failed_flag_off",
+                        error=error,
                         scopes=required_scopes,
                     )
-                    return await func(*args, **kwargs)
-                # No valid auth
-                logger.warning(
-                    "machine_jwt_auth_failed_flag_off",
-                    error=error,
+                    return jsonify({"error": "Unauthorized: invalid token"}), 401
+
+                # Enforce required scopes against token's allowlist (least privilege)
+                required_scope_set = set(required_scopes)
+                if not required_scope_set.issubset(allowed_scopes):
+                    logger.warning(
+                        "legacy_token_insufficient_scope",
+                        required=required_scopes,
+                        allowed=list(allowed_scopes),
+                    )
+                    return (
+                        jsonify(
+                            {"error": "Forbidden: insufficient scope for legacy token"}
+                        ),
+                        403,
+                    )
+
+                # Legacy static token accepted with proper scopes
+                g.machine_tenant = "default"
+                g.machine_sub = "legacy"
+                logger.info(
+                    "legacy_token_authenticated",
+                    tenant=g.machine_tenant,
                     scopes=required_scopes,
                 )
-                return jsonify({"error": "Unauthorized: invalid token"}), 401
+                return await func(*args, **kwargs)
             else:
                 # Flag ON: machine-JWT required, legacy disabled
                 logger.warning(

--- a/hub_api/core/api/certs.py
+++ b/hub_api/core/api/certs.py
@@ -8,8 +8,9 @@ from datetime import datetime, timezone
 from typing import Any
 
 import structlog
-from quart import Blueprint, current_app, request
+from quart import Blueprint, current_app, g, request
 
+from hub_api.auth.middleware import require_machine_jwt
 from hub_api.core import CertificateManager
 from hub_api.entitlements.gate import require_feature
 
@@ -64,11 +65,12 @@ def _verify_enrollment_token(token: str | None) -> bool:
 
 @blueprint.route("/certificates", methods=["POST"])
 @require_feature("sase", "certs")
+@require_machine_jwt("certs:issue")
 async def generate_certificate() -> tuple[dict[str, Any], int]:
     """Generate a signed X.509 certificate for a node.
 
-    Phase-0 endpoint: requires enrollment token (bootstrap token),
-    not a tenant JWT. Used during node onboarding.
+    Requires machine-JWT with certs:issue scope (or legacy enrollment token if flag OFF).
+    Used during node onboarding and cert renewal.
 
     Request body:
     {
@@ -83,19 +85,6 @@ async def generate_certificate() -> tuple[dict[str, Any], int]:
         JSON response with certificate type and PEM-encoded cert/key/CA.
     """
     try:
-        # Verify enrollment token (Phase-0 gating - not a tenant JWT)
-        auth_header = request.headers.get("Authorization")
-        enrollment_token = _extract_bearer_token(auth_header)
-
-        if not _verify_enrollment_token(enrollment_token):
-            logger.warning(
-                "certificate_generation_unauthorized",
-                reason="invalid_enrollment_token",
-            )
-            return (
-                {"error": "Unauthorized: enrollment token required"},
-                401,
-            )
 
         # Parse request body
         data = await request.get_json()

--- a/hub_api/modules/sdwan/api/clients.py
+++ b/hub_api/modules/sdwan/api/clients.py
@@ -13,9 +13,14 @@ from dataclasses import dataclass
 from datetime import datetime, timezone
 from typing import Any
 
-from quart import Blueprint, current_app, jsonify, request
+from quart import Blueprint, current_app, g, jsonify, request
 
-from hub_api.auth.middleware import current_claims, require_scope, require_tenant
+from hub_api.auth.middleware import (
+    current_claims,
+    require_machine_jwt,
+    require_scope,
+    require_tenant,
+)
 from hub_api.db import get_db
 from hub_api.entitlements.gate import require_feature
 from hub_api.modules.sdwan.orchestrator.client_registry import ClientRegistry
@@ -446,10 +451,11 @@ async def submit_client_metrics(client_id: str) -> tuple[dict[str, Any], int]:
 
 
 @blueprint.route("/headends/<headend_id>/metrics", methods=["POST"])
+@require_machine_jwt("metrics:write")
 async def submit_headend_metrics(headend_id: str) -> tuple[dict[str, Any], int]:
     """Submit metrics from a headend/cluster.
 
-    Requires valid cluster authentication (bootstrap token or API key).
+    Requires valid machine-JWT with metrics:write scope.
     Verifies the authenticated cluster matches the headend_id in path.
 
     Args:
@@ -459,22 +465,8 @@ async def submit_headend_metrics(headend_id: str) -> tuple[dict[str, Any], int]:
         JSON response with status.
     """
     try:
-        # Extract and validate authentication token
-        auth_header = request.headers.get("Authorization", "")
-        if not auth_header.startswith("Bearer "):
-            return {"error": "Invalid authorization header"}, 401
-
-        token = auth_header[len("Bearer "):].strip()
-        if not token:
-            return {"error": "Unauthorized: missing token"}, 401
-
         db = get_db()
-        tenant_id = "default"  # Phase-0: default tenant for cluster/headend auth
-
-        # Authenticate cluster/headend via bootstrap token (Phase-0)
-        # Future: Replace with ClusterManager.authenticate_cluster(token) when available
-        if not _verify_bootstrap_token(token):
-            return {"error": "Unauthorized: invalid credentials"}, 401
+        tenant_id = g.machine_tenant  # regression: security-review finding-2
 
         # Verify the headend/cluster exists and matches the path parameter
         cluster_mgr = ClusterManager(db, tenant_id)

--- a/hub_api/tests/test_machine_jwt_routes.py
+++ b/hub_api/tests/test_machine_jwt_routes.py
@@ -69,6 +69,50 @@ async def machine_jwt_metrics(app: Any, tenant: str = "acme") -> str:
 
 
 @pytest.mark.asyncio
+async def test_flag_off_accepts_static_token(
+    app: Any, mock_db: MagicMock
+) -> None:
+    """Test firewall/rules accepts static token when flag is OFF (dual-accept).
+
+    Regression: backward-compatibility during transition to machine-JWT.
+
+    Args:
+        app: Test app.
+        mock_db: Mock database.
+    """
+    static_token = "test-headend-static-token"
+    import shared.licensing.entitlements
+
+    with patch.dict(os.environ, {"HEADEND_API_TOKEN": static_token}):
+        with patch.object(
+            shared.licensing.entitlements, "_flag_on", return_value=False
+        ):
+            client = app.test_client()
+
+            # Mock UserManager.list_users to return empty list
+            with patch(
+                "hub_api.api.headend_routes.get_user_manager"
+            ) as mock_um_factory:
+                mock_um = MagicMock()
+                mock_um.list_users = AsyncMock(return_value=[])
+                mock_um_factory.return_value = mock_um
+
+                # Mock AccessControlManager
+                with patch(
+                    "hub_api.api.headend_routes.get_access_control_manager"
+                ) as mock_acm_factory:
+                    mock_acm = MagicMock()
+                    mock_acm_factory.return_value = mock_acm
+
+                    # Static token should be accepted when flag is OFF
+                    resp = await client.get(
+                        "/api/v1/firewall/rules",
+                        headers={"Authorization": f"Bearer {static_token}"},
+                    )
+                    assert resp.status_code == 200
+
+
+@pytest.mark.asyncio
 async def test_dual_accept_flag_off_accepts_machine_jwt(
     app: Any, machine_jwt_firewall: str, mock_db: MagicMock
 ) -> None:
@@ -105,6 +149,107 @@ async def test_dual_accept_flag_off_accepts_machine_jwt(
                     headers={"Authorization": f"Bearer {machine_jwt_firewall}"},
                 )
                 assert resp.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_flag_on_rejects_static_token(
+    app: Any, mock_db: MagicMock
+) -> None:
+    """Test firewall/rules rejects static token when flag is ON (enforcement).
+
+    Regression: flag cutover must reject legacy tokens when enabled.
+
+    Args:
+        app: Test app.
+        mock_db: Mock database.
+    """
+    static_token = "test-headend-static-token"
+    import shared.licensing.entitlements
+
+    with patch.dict(os.environ, {"HEADEND_API_TOKEN": static_token}):
+        with patch.object(
+            shared.licensing.entitlements, "_flag_on", return_value=True
+        ):
+            client = app.test_client()
+
+            # Static token must be rejected when flag is ON
+            resp = await client.get(
+                "/api/v1/firewall/rules",
+                headers={"Authorization": f"Bearer {static_token}"},
+            )
+            assert resp.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_flag_on_accepts_machine_jwt(
+    app: Any, machine_jwt_firewall: str, mock_db: MagicMock
+) -> None:
+    """Test firewall/rules accepts machine-JWT when flag is ON.
+
+    Args:
+        app: Test app.
+        machine_jwt_firewall: Valid machine-JWT.
+        mock_db: Mock database.
+    """
+    # Flag ON
+    import shared.licensing.entitlements
+
+    with patch.object(
+        shared.licensing.entitlements, "_flag_on", return_value=True
+    ):
+        client = app.test_client()
+
+        # Mock UserManager.list_users to return empty list
+        with patch("hub_api.api.headend_routes.get_user_manager") as mock_um_factory:
+            mock_um = MagicMock()
+            mock_um.list_users = AsyncMock(return_value=[])
+            mock_um_factory.return_value = mock_um
+
+            # Mock AccessControlManager
+            with patch(
+                "hub_api.api.headend_routes.get_access_control_manager"
+            ) as mock_acm_factory:
+                mock_acm = MagicMock()
+                mock_acm_factory.return_value = mock_acm
+
+                # Machine-JWT must be accepted when flag is ON
+                resp = await client.get(
+                    "/api/v1/firewall/rules",
+                    headers={"Authorization": f"Bearer {machine_jwt_firewall}"},
+                )
+                assert resp.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_finding2_bootstrap_token_rejected_flag_on(
+    app: Any, mock_db: MagicMock
+) -> None:
+    """Test bootstrap token is rejected when flag is ON (Finding-2 enforcement).
+
+    Regression: security-review finding-2 (C6) — metrics must require machine-JWT
+    not shared bootstrap token. Test via firewall/rules endpoint which is always
+    available in test app.
+
+    Args:
+        app: Test app.
+        mock_db: Mock database.
+    """
+    bootstrap_token = "test-bootstrap-token"
+    import shared.licensing.entitlements
+
+    # Flag ON: enforce machine-JWT requirement (bootstrap token must be rejected)
+    with patch.dict(os.environ, {"ENROLLMENT_BOOTSTRAP_TOKEN": bootstrap_token}):
+        with patch.object(
+            shared.licensing.entitlements, "_flag_on", return_value=True
+        ):
+            client = app.test_client()
+
+            # Bootstrap token must be REJECTED when flag is ON
+            resp = await client.get(
+                "/api/v1/firewall/rules",
+                headers={"Authorization": f"Bearer {bootstrap_token}"},
+            )
+            assert resp.status_code == 401
 
 
 @pytest.mark.asyncio

--- a/hub_api/tests/test_machine_jwt_routes.py
+++ b/hub_api/tests/test_machine_jwt_routes.py
@@ -1,0 +1,251 @@
+"""Tests for machine-JWT authentication on protected routes.
+
+Covers dual-accept (flag ON/OFF), tenant scoping (C1/C2),
+and security-review Finding 2 (C6).
+"""
+
+from __future__ import annotations
+
+import os
+from unittest.mock import AsyncMock, MagicMock, patch
+from typing import Any
+
+import pytest
+import pytest_asyncio
+
+from hub_api.auth.jwt import encode_access_token
+from hub_api.auth.machine_claims import build_machine_claims
+from hub_api.crypto import InAppKeyProvider, generate_rsa_key_pair
+
+
+@pytest_asyncio.fixture
+async def machine_jwt_firewall(app: Any, tenant: str = "acme") -> str:
+    """Generate a valid machine-JWT with firewall:read scope.
+
+    Args:
+        app: App with key provider.
+        tenant: Tenant ID (default "acme").
+
+    Returns:
+        Encoded machine-JWT token.
+    """
+    provider = app.config["KEY_PROVIDER"]
+
+    claims = build_machine_claims(
+        sub_id="cluster-1",
+        node_type="kubernetes_node",
+        tenant=tenant,
+        iss="tobogganing",
+        aud="headend",
+    )
+
+    token = await encode_access_token(claims, provider, ttl_hours=1)
+    return token
+
+
+@pytest_asyncio.fixture
+async def machine_jwt_metrics(app: Any, tenant: str = "acme") -> str:
+    """Generate a valid machine-JWT with metrics:write scope.
+
+    Args:
+        app: App with key provider.
+        tenant: Tenant ID (default "acme").
+
+    Returns:
+        Encoded machine-JWT token.
+    """
+    provider = app.config["KEY_PROVIDER"]
+
+    claims = build_machine_claims(
+        sub_id="cluster-1",
+        node_type="kubernetes_node",
+        tenant=tenant,
+        iss="tobogganing",
+        aud="headend",
+    )
+
+    token = await encode_access_token(claims, provider, ttl_hours=1)
+    return token
+
+
+@pytest.mark.asyncio
+async def test_dual_accept_flag_off_accepts_machine_jwt(
+    app: Any, machine_jwt_firewall: str, mock_db: MagicMock
+) -> None:
+    """Test firewall/rules accepts machine-JWT when flag is OFF.
+
+    Args:
+        app: Test app.
+        machine_jwt_firewall: Valid machine-JWT.
+        mock_db: Mock database.
+    """
+    # Flag OFF (default)
+    import shared.licensing.entitlements
+
+    with patch.object(
+        shared.licensing.entitlements, "_flag_on", return_value=False
+    ):
+        client = app.test_client()
+
+        # Mock UserManager.list_users to return empty list
+        with patch("hub_api.api.headend_routes.get_user_manager") as mock_um_factory:
+            mock_um = MagicMock()
+            mock_um.list_users = AsyncMock(return_value=[])
+            mock_um_factory.return_value = mock_um
+
+            # Mock AccessControlManager
+            with patch(
+                "hub_api.api.headend_routes.get_access_control_manager"
+            ) as mock_acm_factory:
+                mock_acm = MagicMock()
+                mock_acm_factory.return_value = mock_acm
+
+                resp = await client.get(
+                    "/api/v1/firewall/rules",
+                    headers={"Authorization": f"Bearer {machine_jwt_firewall}"},
+                )
+                assert resp.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_tenant_scoping_firewall_rules(app: Any, mock_db: MagicMock) -> None:
+    """Test firewall/rules scoped to authenticated tenant (regression C2).
+
+    Verifies that g.machine_tenant is used instead of hardcoded "default".
+
+    Args:
+        app: Test app.
+        mock_db: Mock database.
+    """
+    provider = app.config["KEY_PROVIDER"]
+
+    # Create machine-JWT for tenant "acme"
+    claims = build_machine_claims(
+        sub_id="cluster-1",
+        node_type="kubernetes_node",
+        tenant="acme",
+        iss="tobogganing",
+        aud="headend",
+    )
+    jwt_acme = await encode_access_token(claims, provider, ttl_hours=1)
+
+    # Mock UserManager to verify tenant is passed
+    import shared.licensing.entitlements
+
+    with patch.object(
+        shared.licensing.entitlements, "_flag_on", return_value=True
+    ):
+        client = app.test_client()
+
+        with patch("hub_api.api.headend_routes.get_user_manager") as mock_um_factory:
+            mock_um = MagicMock()
+            mock_um.list_users = AsyncMock(return_value=[])
+            mock_um_factory.return_value = mock_um
+
+            with patch(
+                "hub_api.api.headend_routes.get_access_control_manager"
+            ) as mock_acm_factory:
+                mock_acm = MagicMock()
+                mock_acm_factory.return_value = mock_acm
+
+                resp = await client.get(
+                    "/api/v1/firewall/rules",
+                    headers={"Authorization": f"Bearer {jwt_acme}"},
+                )
+                assert resp.status_code == 200
+
+                # Verify UserManager was called with tenant="acme", not "default"
+                mock_um.list_users.assert_called_once_with("acme")
+
+
+@pytest.mark.asyncio
+async def test_wireguard_peers_tenant_scoping(app: Any, mock_db: MagicMock) -> None:
+    """Test wireguard/peers scoped to authenticated tenant (regression C2).
+
+    Args:
+        app: Test app.
+        mock_db: Mock database.
+    """
+    provider = app.config["KEY_PROVIDER"]
+
+    # Create machine-JWT for tenant "beta"
+    claims = build_machine_claims(
+        sub_id="cluster-2",
+        node_type="kubernetes_node",
+        tenant="beta",
+        iss="tobogganing",
+        aud="headend",
+    )
+    jwt_beta = await encode_access_token(claims, provider, ttl_hours=1)
+
+    # Mock CertificateManager
+    cert_manager = MagicMock()
+    app.config["CERT_MANAGER"] = cert_manager
+    cert_manager.get_all_wireguard_peers = AsyncMock(return_value=[])
+
+    import shared.licensing.entitlements
+
+    with patch.object(
+        shared.licensing.entitlements, "_flag_on", return_value=True
+    ):
+        client = app.test_client()
+
+        resp = await client.get(
+            "/api/v1/wireguard/peers",
+            headers={"Authorization": f"Bearer {jwt_beta}"},
+        )
+        assert resp.status_code == 200
+
+        # Verify CertificateManager was called with tenant_id="beta"
+        cert_manager.get_all_wireguard_peers.assert_called_once_with(tenant_id="beta")
+
+
+@pytest.mark.asyncio
+async def test_headend_ports_tenant_scoping(app: Any, mock_db: MagicMock) -> None:
+    """Test headend/ports scoped to authenticated tenant (regression C2).
+
+    Args:
+        app: Test app.
+        mock_db: Mock database.
+    """
+    provider = app.config["KEY_PROVIDER"]
+
+    # Create machine-JWT for tenant "prod"
+    claims = build_machine_claims(
+        sub_id="cluster-3",
+        node_type="kubernetes_node",
+        tenant="prod",
+        iss="tobogganing",
+        aud="headend",
+    )
+    jwt_prod = await encode_access_token(claims, provider, ttl_hours=1)
+
+    import shared.licensing.entitlements
+
+    with patch.object(
+        shared.licensing.entitlements, "_flag_on", return_value=True
+    ):
+        client = app.test_client()
+
+        # Mock PortConfigManager
+        with patch(
+            "hub_api.api.headend_routes.get_port_config_manager"
+        ) as mock_pcm_factory:
+            mock_pcm = MagicMock()
+            mock_config = MagicMock()
+            mock_config.headend_id = "headend-1"
+            mock_config.cluster_id = "cluster-3"
+            mock_config.tcp_ranges = []
+            mock_config.udp_ranges = []
+            mock_config.updated_at = None
+            mock_pcm.get_headend_config = AsyncMock(return_value=mock_config)
+            mock_pcm_factory.return_value = mock_pcm
+
+            resp = await client.get(
+                "/api/v1/headend/headend-1/ports",
+                headers={"Authorization": f"Bearer {jwt_prod}"},
+            )
+            assert resp.status_code == 200
+
+            # Verify PortConfigManager was called with tenant="prod"
+            mock_pcm.get_headend_config.assert_called_once_with("headend-1", "prod")

--- a/hub_api/tests/test_machine_jwt_routes.py
+++ b/hub_api/tests/test_machine_jwt_routes.py
@@ -253,6 +253,171 @@ async def test_finding2_bootstrap_token_rejected_flag_on(
 
 
 @pytest.mark.asyncio
+async def test_client_node_lacks_privileged_scopes(app: Any) -> None:
+    """Test client node types have minimal scopes (least privilege).
+
+    Regression: client_docker/client_native should NOT have
+    firewall:read, ports:read, metrics:write, or certs:issue.
+
+    Args:
+        app: Test app.
+    """
+    provider = app.config["KEY_PROVIDER"]
+
+    # Create machine-JWT for client node
+    claims = build_machine_claims(
+        sub_id="client-1",
+        node_type="client_docker",
+        tenant="acme",
+        iss="tobogganing",
+        aud="headend",
+    )
+
+    # Client should only have wireguard:read, NOT privileged scopes
+    assert "wireguard:read" in claims["scope"]
+    assert "firewall:read" not in claims["scope"]
+    assert "ports:read" not in claims["scope"]
+    assert "metrics:write" not in claims["scope"]
+    assert "certs:issue" not in claims["scope"]
+
+
+@pytest.mark.asyncio
+async def test_cluster_node_has_full_scopes(app: Any) -> None:
+    """Test cluster node types have full scopes.
+
+    Regression: kubernetes_node/raw_compute should have all scopes
+    including certs:issue for cert issuance operations.
+
+    Args:
+        app: Test app.
+    """
+    provider = app.config["KEY_PROVIDER"]
+
+    # Create machine-JWT for cluster node
+    claims = build_machine_claims(
+        sub_id="cluster-1",
+        node_type="kubernetes_node",
+        tenant="acme",
+        iss="tobogganing",
+        aud="headend",
+    )
+
+    # Cluster should have all scopes
+    assert "firewall:read" in claims["scope"]
+    assert "wireguard:read" in claims["scope"]
+    assert "ports:read" in claims["scope"]
+    assert "metrics:write" in claims["scope"]
+    assert "certs:issue" in claims["scope"]
+
+
+@pytest.mark.asyncio
+async def test_legacy_headend_token_insufficient_scope_for_certs(
+    app: Any, mock_db: MagicMock
+) -> None:
+    """Test headend token cannot issue certs (scope enforcement).
+
+    Regression: legacy headend token should NOT have certs:issue scope;
+    attempting to access cert endpoint should return 403 (insufficient scope).
+
+    Args:
+        app: Test app.
+        mock_db: Mock database.
+    """
+    headend_token = "test-headend-token"
+    import shared.licensing.entitlements
+
+    # Flag OFF: legacy token fallback enabled
+    with patch.dict(os.environ, {"HEADEND_API_TOKEN": headend_token}):
+        with patch.object(
+            shared.licensing.entitlements, "_flag_on", return_value=False
+        ):
+            # Mock feature gate for certs endpoint
+            with patch("hub_api.entitlements.gate.feature_enabled", return_value=True):
+                client = app.test_client()
+
+                # Headend token attempting to access certs endpoint
+                # should fail with 403 (insufficient scope), not 200
+                resp = await client.post(
+                    "/api/v1/certs/certificates",
+                    headers={"Authorization": f"Bearer {headend_token}"},
+                    json={"type": "client", "id": "node-1", "name": "test"},
+                )
+                assert resp.status_code == 403
+                data = await resp.get_json()
+                assert "insufficient scope" in data["error"].lower()
+
+
+@pytest.mark.asyncio
+async def test_legacy_bootstrap_token_insufficient_scope_for_firewall(
+    app: Any, mock_db: MagicMock
+) -> None:
+    """Test bootstrap token cannot read firewall (scope enforcement).
+
+    Regression: legacy bootstrap token should NOT have firewall:read scope;
+    attempting to read firewall rules should return 403 (insufficient scope).
+
+    Args:
+        app: Test app.
+        mock_db: Mock database.
+    """
+    bootstrap_token = "test-bootstrap-token"
+    import shared.licensing.entitlements
+
+    # Flag OFF: legacy token fallback enabled
+    with patch.dict(os.environ, {"ENROLLMENT_BOOTSTRAP_TOKEN": bootstrap_token}):
+        with patch.object(
+            shared.licensing.entitlements, "_flag_on", return_value=False
+        ):
+            client = app.test_client()
+
+            # Bootstrap token attempting to read firewall rules
+            # should fail with 403 (insufficient scope), not 200
+            resp = await client.get(
+                "/api/v1/firewall/rules",
+                headers={"Authorization": f"Bearer {bootstrap_token}"},
+            )
+            assert resp.status_code == 403
+            data = await resp.get_json()
+            assert "insufficient scope" in data["error"].lower()
+
+
+@pytest.mark.asyncio
+async def test_legacy_bootstrap_token_can_issue_certs(
+    app: Any, mock_db: MagicMock
+) -> None:
+    """Test bootstrap token CAN issue certs (within its allowlist).
+
+    Regression: legacy bootstrap token should have certs:issue scope;
+    accessing cert endpoint should succeed (or fail on validation, not auth).
+
+    Args:
+        app: Test app.
+        mock_db: Mock database.
+    """
+    bootstrap_token = "test-bootstrap-token"
+    import shared.licensing.entitlements
+
+    # Flag OFF: legacy token fallback enabled
+    with patch.dict(os.environ, {"ENROLLMENT_BOOTSTRAP_TOKEN": bootstrap_token}):
+        with patch.object(
+            shared.licensing.entitlements, "_flag_on", return_value=False
+        ):
+            # Mock feature gate for certs endpoint
+            with patch("hub_api.entitlements.gate.feature_enabled", return_value=True):
+                client = app.test_client()
+
+                # Bootstrap token should be accepted for cert issuance
+                # (not rejected with 403 insufficient scope)
+                resp = await client.post(
+                    "/api/v1/certs/certificates",
+                    headers={"Authorization": f"Bearer {bootstrap_token}"},
+                    json={"type": "client", "id": "node-1", "name": "test"},
+                )
+                # Should NOT be 403 auth error; might be 400/500 validation error
+                assert resp.status_code != 403
+
+
+@pytest.mark.asyncio
 async def test_tenant_scoping_firewall_rules(app: Any, mock_db: MagicMock) -> None:
     """Test firewall/rules scoped to authenticated tenant (regression C2).
 

--- a/hub_api/tests/test_sase_api_crypto.py
+++ b/hub_api/tests/test_sase_api_crypto.py
@@ -152,7 +152,8 @@ async def test_certificate_generation_requires_enrollment_token(
 
         assert response.status_code == 401
         data = await response.get_json()
-        assert "enrollment token" in data["error"].lower()
+        # With decorator, error message is generic "invalid authorization header"
+        assert "authorization" in data["error"].lower() or "unauthorized" in data["error"].lower()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Task 3 of the auth-redesign plan — the security core. Closes C1 (static-token routes), C2 (tenant scoping), C6/Finding-2 (metrics bootstrap token).

- `require_machine_jwt(*scopes)` decorator; SPIFFE-ready (identity extraction isolated). Dual-accept behind flag `tobogganing.core.machine_jwt_required` (default OFF).
- Applied to firewall/rules, wireguard/peers, headend/ports, submit_headend_metrics, cert issuance; all scope queries to `g.machine_tenant` (no hardcoded "default").
- **Least-privilege (commit security review, 3 HIGH)**: scopes derived from node_type (`CLUSTER_SCOPES` vs minimal `CLIENT_SCOPES`; clients lack certs:issue/firewall); legacy fallback enforces required_scopes against per-token allowlists (HEADEND→{firewall/wireguard/ports:read,metrics:write}, BOOTSTRAP→{certs:issue}) — a headend token can no longer issue certs.

Verified: 13 route tests + 5 issuance tests (incl. flag-on-rejects-static, Finding-2, and the 5 least-privilege regressions) pass; broader auth batch 111 pass; boot OK; collect 882/0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)