### PR TITLE
docs(auth): Go-headend machine-JWT contract + spec scope correction (auth redesign T6)

### DIFF
--- a/docs/architecture/headend-machine-jwt-contract.md
+++ b/docs/architecture/headend-machine-jwt-contract.md
@@ -1,0 +1,50 @@
+# Headend Machine-JWT Contract (Go ↔ Quart brain)
+
+**Status**: Quart side implemented (auth redesign T1–T5, findings C+D). **Go headend change pending — separate session.**
+**Cross-references**: `docs/superpowers/specs/2026-07-29-auth-redesign-cd-design.md`; hub-topology spec §8 #11/#12, §10.
+
+## Purpose
+
+The Quart brain now authenticates the Go headend (and clusters/clients) with **per-cluster machine-JWTs** carrying tenant + scope claims, replacing the global static `HEADEND_API_TOKEN` and the shared `ENROLLMENT_BOOTSTRAP_TOKEN` on the machine-plane routes. This document is the hand-off contract the Go headend must implement. Until it does, the transition flag stays **OFF** and the legacy static tokens keep working (dual-accept).
+
+## What the Go headend must do
+
+1. **Exchange its `CLUSTER_API_KEY` for a machine-JWT** at startup:
+   `POST /api/v1/auth/token` with `{"node_id": "<cluster-id>", "node_type": "kubernetes_node", "api_key": "<CLUSTER_API_KEY>"}`.
+   Response: `{"access_token": <1h JWT>, "refresh_token": <8h rotating JWT>, ...}`.
+2. **Send `Authorization: Bearer <access_token>`** on every machine-plane route — this *replaces the current split* where the Go side used `authToken` (=`HEADEND_API_TOKEN`) for `firewall/rules`+`ports` and `CLUSTER_API_KEY` for `wireguard/peers` (spec §8 #11). One cluster identity now covers all of them:
+   - `GET /api/v1/firewall/rules` (scope `firewall:read`)
+   - `GET /api/v1/wireguard/peers` (scope `wireguard:read`)
+   - `GET /api/v1/headend/<id>/ports` (scope `ports:read`)
+   - `POST /api/v1/clients/headends/<id>/metrics` (scope `metrics:write` — **was the shared bootstrap token; now the cluster machine-JWT**, closing security-review Finding 2)
+3. **Store the rotated refresh token and refresh before the access token expires** (`POST /api/v1/auth/refresh` with `{"refresh_token": <current>}`). Refresh is **single-use**: each call returns a NEW refresh token; the old one is immediately invalid. Persist the newest one; a replay of a superseded refresh token is treated as compromise and **revokes the cluster** (all its tokens).
+4. **On `503 {"retry_with_credentials": true}`** from `/auth/refresh** (the brain's Valkey revocation store is unreachable — fail-closed), fall back to step 1: re-authenticate with `CLUSTER_API_KEY`. No hard outage.
+5. **Cert issuance** (`POST /api/v1/certs/certificates`, scope `certs:issue`) remains the **enrollment** path: a bootstrapping node presents the `ENROLLMENT_BOOTSTRAP_TOKEN` (legacy) or a cluster with `certs:issue` in its machine-JWT scope issues client certs. The `HEADEND_API_TOKEN` can NOT issue certs.
+
+## Scope model (what each identity is allowed)
+
+Machine-JWT scopes are derived from `node_type` (least-privilege):
+
+| node_type | scopes |
+|-----------|--------|
+| `kubernetes_node` / `raw_compute` / `headend` (clusters) | `firewall:read wireguard:read ports:read metrics:write certs:issue` |
+| `client_docker` / `client_native` (clients) | `wireguard:read` |
+
+During the dual-accept window (flag OFF), the two legacy static tokens map to fixed allowlists (a legacy token can only satisfy its own scopes):
+
+| legacy token | allowed scopes |
+|--------------|----------------|
+| `HEADEND_API_TOKEN` | `firewall:read`, `wireguard:read`, `ports:read`, `metrics:write` |
+| `ENROLLMENT_BOOTSTRAP_TOKEN` | `certs:issue` |
+
+## Cutover
+
+- Flag `tobogganing.core.machine_jwt_required` — **default OFF** = dual-accept (legacy static tokens + machine-JWTs both work). No lockstep deploy.
+- Once the Go headend ships steps 1–4 and is deployed, flip the flag **ON** — legacy static tokens are then rejected (401), machine-JWT only. Verified by `test_flag_on_rejects_static_token`.
+- Rollback: flip the flag OFF to restore legacy acceptance.
+
+## Notes
+
+- Tenant: the machine-JWT carries the cluster's real `tenant`; the brain scopes every machine-plane query to it (no more hardcoded `"default"`).
+- Credential rotation: the brain exposes `ClusterManager.rotate_api_key` — rotating a cluster's `CLUSTER_API_KEY` invalidates the old key; the headend must re-run step 1 with the new key.
+- Longer-term: this machine-JWT is the OIDC-machine-JWT **fallback** in the SPIFFE model — every service is built SPIFFE-ready (accepts an X.509-SVID as a first-class identity), so adopting SPIRE later is a config change, not a rewrite (see `security.md` Service-to-Service Auth, hub-topology §8 #4). The `require_machine_jwt` decorator isolates identity extraction in one place for exactly this.

--- a/docs/superpowers/specs/2026-07-29-auth-redesign-cd-design.md
+++ b/docs/superpowers/specs/2026-07-29-auth-redesign-cd-design.md
@@ -50,7 +50,9 @@ New package: a single async-friendly Valkey client the whole app shares, replaci
 - **Access JWT** (1h): `sub="cluster:<id>"`, `iss`, `aud="headend"`, `tenant=<cluster.tenant>` (FIX C3: read `.tenant`, not `.tenant_id`), `scope="firewall:read wireguard:read ports:read metrics:write"`, `iat`, `exp`, `jti`.
 - **Refresh JWT** (short, default 8h — configurable; ≤24h per standards): `token_type="refresh"`, `sub`, `tenant`, `aud`, `jti`, `exp`.
 - FIX C4: `await authenticate_cluster(...)` directly (it is async); remove the `asyncio.to_thread` wrapper on the coroutine. Bind `cluster.id==node_id` (the existing A-fix) — which now actually runs.
-- Scope set derives from cluster role/type; keep a single machine scope-bundle for now (`machine`) expanded to the resource scopes above.
+- **Scope set derives from `node_type` (least-privilege — corrected after commit security review; a single union bundle was over-permissive):**
+  - clusters (`kubernetes_node`/`raw_compute`/`headend`) → `firewall:read wireguard:read ports:read metrics:write certs:issue` (clusters are the cert issuers)
+  - clients (`client_docker`/`client_native`) → `wireguard:read` (minimal; NO `certs:issue`/`firewall`/`ports`/`metrics`)
 
 ### 3. Rotating refresh + revocation — `hub_api/auth/refresh.py` (new) + Valkey
 
@@ -65,7 +67,7 @@ New package: a single async-friendly Valkey client the whole app shares, replaci
 
 New decorator `@require_machine_jwt(*scopes)`:
 - Extract Bearer token. Try machine-JWT decode first: valid + `aud=="headend"` + required scopes present + not denylisted → set `g.machine_tenant`, `g.machine_sub`; proceed.
-- If not a valid machine-JWT AND flag `tobogganing.core.machine_jwt_required` is **OFF** → fall back to `_verify_headend_token`/`_verify_bootstrap_token` (legacy static token), set `g.machine_tenant="default"` (legacy).
+- If not a valid machine-JWT AND flag `tobogganing.core.machine_jwt_required` is **OFF** → legacy fallback, but **each legacy token is bound to a fixed scope allowlist and `required_scopes` is enforced against it** (corrected after commit security review — a bare "accept either static token for any route" was a privilege-escalation window): `HEADEND_API_TOKEN → {firewall:read, wireguard:read, ports:read, metrics:write}`, `ENROLLMENT_BOOTSTRAP_TOKEN → {certs:issue}`. `required_scopes ⊄ allowlist` → 403. Set `g.machine_tenant="default"` (legacy). Net effect: a headend token can NOT issue certs; a bootstrap token can NOT read firewall.
 - If flag **ON** → legacy path disabled; static token → 401.
 - Applied to: `firewall/rules`, `wireguard/peers`, `headend/ports` (`headend_routes.py`), `submit_headend_metrics` (FIX C6 — replaces bootstrap), cert issuance (`core/api/certs.py`).
 - **Every query in these handlers is scoped to `g.machine_tenant`** (FIX C2), not `"default"`.


### PR DESCRIPTION
Task 6 — the Go-headend coordination contract + spec fix.

- `docs/architecture/headend-machine-jwt-contract.md`: the hand-off the Go headend implements (CLUSTER_API_KEY→machine-JWT, bearer on all headend routes replacing the authToken/CLUSTER_API_KEY split, rotated single-use refresh, 503 re-auth, cutover flag, scope + legacy-allowlist tables).
- Corrects the spec's over-simplified 'single scope bundle' → node_type CLUSTER/CLIENT scopes + per-token legacy allowlists (root cause of the least-privilege findings the review caught).

Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)