### PR TITLE
docs(sase): Slice A STIX IOC blocklist spec + plan

### DIFF
--- a/docs/superpowers/plans/2026-07-29-sase-slice-a-blocklist.md
+++ b/docs/superpowers/plans/2026-07-29-sase-slice-a-blocklist.md
@@ -1,0 +1,178 @@
+# SASE Slice A — STIX IOC Blocklist Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: superpowers:subagent-driven-development. Steps use checkbox (`- [ ]`). Executed by `penguin-python-dev` — PenguinTech Python conventions (async, `@dataclass(slots=True)`, type hints, structlog, penguin-dal).
+
+**Goal:** A STIX-2.1-normalized IOC blocklist in Valkey, seeded from the existing `threat_indicators` feeds, readable O(1) by Inspection Points — the shared detection→block store for the SASE loop.
+
+**Architecture:** Canonical STIX 2.1 Indicators (OASIS `stix2` lib) for interchange/audit + a denormalized Valkey fast-index (`sase:blocklist:{ip,domain,url,hash}:<value>` → compact `Verdict`) over the existing `CacheClient`. A curator populates the index from `threat_indicators`; `check()` fails **open**.
+
+**Tech Stack:** Python 3.13, `stix2` (OASIS), `hub_api/cache/CacheClient`, penguin-dal, Quart.
+
+## Global Constraints
+
+- Spec: `docs/superpowers/specs/2026-07-29-sase-slice-a-blocklist-design.md` — authoritative.
+- Green gate: `python3 -m pytest hub_api/tests/` (baseline **899**, 0 fail) in **targeted batches** (env kills >~120s); `create_app()` boots; `scripts/audit_imports.py --module sase --forbid sdwan,ziti` clean. Clean bytecode first: `find hub_api -type d -name __pycache__ -exec rm -rf {} +`.
+- **Commit-completeness (hard):** after each commit `git status --short` empty + `git show HEAD --stat` lists every file; `git check-ignore` every NEW file (module lives under `sase/security/blocklist/` — not a `certs/` dir, but verify); after `git push` confirm `git log --oneline -1 origin/<branch>` == your SHA.
+- **`check()` fails OPEN** (cache error → `None` → traffic allowed) — out-of-band mandate, never add latency. `put`/`curate` fail soft (log + continue).
+- All Valkey keys under `sase:blocklist` namespace (the `CacheClient` guard enforces it). URL keyed by `sha256(url)` to bound key length.
+- New dep `stix2`: pin exact version + hash via `uv pip compile --generate-hashes` into `hub_api/requirements.{in,txt}`.
+- Flag `tobogganing.sase.blocklist` — community, default OFF.
+
+---
+
+## Task 1: Verdict models + STIX normalizer (+ pin `stix2`)
+
+**Files:**
+- Create: `hub_api/modules/sase/security/blocklist/__init__.py`, `models.py`, `stix_normalizer.py`
+- Modify: `hub_api/requirements.in` (+`stix2`), `hub_api/requirements.txt` (recompiled with hashes)
+- Test: `hub_api/tests/test_sase_blocklist_normalizer.py`
+
+**Interfaces:**
+- Produces: `@dataclass(slots=True) Verdict(ioc_type, value, severity, source, stix_id, first_seen, expiry)`; `IOC_TYPES = ("ip","domain","url","hash")`; `SEVERITIES = ("low","medium","high","critical")`; `to_stix_indicator(ioc_type, value, *, severity, source, first_seen) -> stix2.Indicator`.
+
+- [ ] **Step 1: Add + pin `stix2`** — add `stix2` to `requirements.in`; `cd hub_api && uv pip compile requirements.in --generate-hashes -o requirements.txt`; `uv pip install --require-hashes -r requirements.txt` (or `pip install stix2` if uv unavailable, but the committed txt MUST have the hash). Confirm `python3 -c "import stix2; print(stix2.__version__)"`.
+- [ ] **Step 2: Write failing test** (`test_sase_blocklist_normalizer.py`):
+
+```python
+import stix2
+from hub_api.modules.sase.security.blocklist.stix_normalizer import to_stix_indicator
+
+def test_ip_indicator_pattern():
+    ind = to_stix_indicator("ip", "1.2.3.4", severity="high", source="spamhaus", first_seen=1000)
+    assert ind.pattern == "[ipv4-addr:value = '1.2.3.4']"
+    assert "malicious-activity" in ind.labels
+    assert stix2.parse(ind.serialize()).id == ind.id   # round-trips
+
+def test_domain_and_hash_and_url_patterns():
+    assert to_stix_indicator("domain","bad.com",severity="low",source="ut1",first_seen=1).pattern == "[domain-name:value = 'bad.com']"
+    assert to_stix_indicator("hash","a"*64,severity="critical",source="strelka",first_seen=1).pattern == "[file:hashes.'SHA-256' = '%s']" % ("a"*64)
+    assert to_stix_indicator("url","http://x/y",severity="medium",source="urlhaus",first_seen=1).pattern == "[url:value = 'http://x/y']"
+```
+
+- [ ] **Step 3: Run → FAIL** (module missing).
+- [ ] **Step 4: Implement** `models.py` (Verdict dataclass + constants) and `stix_normalizer.py` (`to_stix_indicator` building the pattern per type via `stix2.Indicator(pattern=..., pattern_type="stix", labels=["malicious-activity"], valid_from=<from first_seen>, confidence=<severity→int>, external_references=[stix2.ExternalReference(source_name=source)])`). Map severity→confidence (low=15/med=50/high=75/crit=95). 2-3 line docstrings.
+- [ ] **Step 5: Run → PASS.**
+- [ ] **Step 6: Green gate** (batch: new test; then `test_sase_feeds*.py` untouched) + commit.
+
+---
+
+## Task 2: `BlocklistStore` over `CacheClient`
+
+**Files:**
+- Create: `hub_api/modules/sase/security/blocklist/store.py`
+- Test: `hub_api/tests/test_sase_blocklist_store.py`
+
+**Interfaces:**
+- Consumes: `CacheClient` (`get/set/delete("sase:blocklist", *parts, ..., fail_closed=)`), `Verdict` (T1).
+- Produces: `BlocklistStore(cache)` with `async put(verdict) -> None`, `async check(ioc_type, value) -> Verdict|None`, `async remove(ioc_type, value) -> None`; `_key(ioc_type, value)` (url → `sha256(value)`).
+
+- [ ] **Step 1: Write failing tests:**
+
+```python
+@pytest.mark.asyncio
+async def test_put_check_roundtrip(store):
+    await store.put(Verdict("ip","1.2.3.4","high","spamhaus","indicator--x",1000,None))
+    v = await store.check("ip","1.2.3.4")
+    assert v.severity == "high" and v.source == "spamhaus"
+
+@pytest.mark.asyncio
+async def test_dedup_higher_severity_wins(store):
+    await store.put(Verdict("domain","b.com","low","a","id1",1,None))
+    await store.put(Verdict("domain","b.com","critical","b","id2",2,None))
+    assert (await store.check("domain","b.com")).severity == "critical"
+
+@pytest.mark.asyncio
+async def test_check_fails_open_on_cache_error(store_with_dead_cache):
+    assert await store_with_dead_cache.check("ip","9.9.9.9") is None   # no raise
+
+@pytest.mark.asyncio
+async def test_url_keyed_by_hash(store):
+    await store.put(Verdict("url","http://x/"+ "a"*500,"high","urlhaus","id",1,None))
+    assert await store.check("url","http://x/"+ "a"*500) is not None
+```
+
+- [ ] **Step 2: Run → FAIL.**
+- [ ] **Step 3: Implement** `BlocklistStore`: serialize `Verdict` to JSON for the value; `put` reads any existing entry and keeps the higher `SEVERITIES.index` (tie → newer `first_seen`); TTL from `expiry` (`ttl_seconds = expiry - now` if set). `check` uses `cache.get(..., fail_closed=False)` wrapped so ANY error → `None` (fail open). `_key`: url → `hashlib.sha256(value.encode()).hexdigest()`, else the raw value.
+- [ ] **Step 4: Run → PASS** (use a `CacheClient` on an unreachable port for the fail-open test; for roundtrip use the in-memory fallback path — study `test_cache_client.py`).
+- [ ] **Step 5: Green gate** + commit.
+
+---
+
+## Task 3: `BlocklistCurator` from `threat_indicators`
+
+**Files:**
+- Create: `hub_api/modules/sase/security/blocklist/curator.py`
+- Test: `hub_api/tests/test_sase_blocklist_curator.py`
+
+**Interfaces:**
+- Consumes: penguin-dal `threat_indicators` table (read the existing schema in `feeds/models.py` for column names — `indicator_type`, `value`, `severity`, `source`, timestamps), `BlocklistStore` (T2), `to_stix_indicator` (T1).
+- Produces: `BlocklistCurator(dal, store)` with `async curate() -> CurationStats`, `async curate_one(row) -> bool`; `@dataclass(slots=True) CurationStats(scanned, stored, deduped, skipped)`.
+
+- [ ] **Step 1: Read** `feeds/models.py` + `feeds/manager.py` to learn the exact `threat_indicators` columns + how `feeds` maps its indicator types to the `ioc_type` set (`ip`/`domain`/…). Map feed indicator_type → blocklist IOC_TYPES; skip unmappable with a warning.
+- [ ] **Step 2: Write failing tests** (real-DAL, mirror `test_sase_feeds_realdal.py`):
+
+```python
+@pytest.mark.asyncio
+async def test_curate_populates_store(real_dal, store):
+    # seed 2 threat_indicators rows (ip high, domain low)
+    stats = await BlocklistCurator(real_dal, store).curate()
+    assert stats.stored == 2
+    assert (await store.check("ip", "<seeded-ip>")).severity == "high"
+
+@pytest.mark.asyncio
+async def test_curate_dedups_same_ioc(real_dal, store):
+    # seed two rows same domain, low then critical
+    await BlocklistCurator(real_dal, store).curate()
+    assert (await store.check("domain","<d>")).severity == "critical"
+
+@pytest.mark.asyncio
+async def test_curate_skips_malformed_without_crashing(real_dal, store):
+    # seed a row with an unmappable indicator_type
+    stats = await BlocklistCurator(real_dal, store).curate()
+    assert stats.skipped >= 1   # run completed, did not raise
+```
+
+- [ ] **Step 3: Run → FAIL.**
+- [ ] **Step 4: Implement** `curate()`: select active `threat_indicators` rows, map each to `(ioc_type, value, severity, source, first_seen)`, `to_stix_indicator(...)` → `stix_id`, build `Verdict`, `await store.put(...)`; count stats; wrap each row in try/except → `skipped += 1` on error (never abort the run). `curate_one(row)` for the feed-ingest hook. Log a masked summary.
+- [ ] **Step 5: Run → PASS.**
+- [ ] **Step 6: Green gate** + commit.
+
+---
+
+## Task 4: Flag + read-API + sase contract registration
+
+**Files:**
+- Create: `hub_api/modules/sase/security/blocklist/api.py` (read-only `GET /api/v1/sase/blocklist/check`)
+- Modify: `hub_api/modules/sase/__init__.py` (add `tobogganing.sase.blocklist` flag + entitlement community; register the blueprint)
+- Test: `hub_api/tests/test_sase_blocklist_api.py`
+
+**Interfaces:**
+- Consumes: `BlocklistStore`, `require_scope`/flag-gate, `app.config["CACHE"]`.
+- Produces: `GET /api/v1/sase/blocklist/check?type=&value=` → `200 {verdict DTO}` or `404` if not blocklisted / flag OFF.
+
+- [ ] **Step 1: Write failing tests** — check endpoint returns the verdict DTO (typed, exact field set — output-validation rule); unknown IOC → 404; flag OFF → 404/disabled; invalid `type` → 400.
+- [ ] **Step 2: Run → FAIL.**
+- [ ] **Step 3: Implement** the blueprint (flag-gated via `feature_enabled("tobogganing.sase","blocklist")`, `require_scope` for read), returning a typed DTO (dataclass/`@validate_response`), never the raw Verdict internals beyond the declared fields. Add the flag + `Entitlement("sase.blocklist","community")` + the blueprint to the sase `module()` contract.
+- [ ] **Step 4: Run → PASS.**
+- [ ] **Step 5: Green gate** (batch: new test + `test_sase_module.py` + `test_registry.py`) + boot check (blueprint mounts) + commit.
+
+---
+
+## Task 5: Enforcement-contract doc
+
+**Files:**
+- Create: `docs/architecture/sase-blocklist-enforcement-contract.md`
+
+- [ ] **Step 1:** Document how the Go/Rust Inspection Point reads `sase:blocklist:*` (read-only ACL on that prefix) from the shared Valkey, checks per-flow IOCs (dest IP/domain, requested URL sha256, file hash) against the store, enforces on **future** traffic only (no per-request gRPC), and **fails open** on miss/outage. Note the verdict→action mapping is Slice-B policy. Commit.
+
+---
+
+## Self-Review
+
+- **Spec coverage:** two representations→T1+T2; store `sase:blocklist:*` + fail-open→T2; curator from feeds→T3; flag/read-API/contract→T4; enforcement contract→T5; `stix2` dep→T1. All covered.
+- **Placeholders:** none — the read-API is a concrete endpoint, not a maybe.
+- **Type consistency:** `Verdict`, `to_stix_indicator`, `BlocklistStore.{put,check,remove}`, `BlocklistCurator.{curate,curate_one}`, `CurationStats` — consistent across tasks.
+
+## Execution
+
+Sequential (2 needs 1; 3 needs 2; 4 needs 2). Single feature branch `feature/sase-blocklist` off release (or a short stack). Dispatch `penguin-python-dev` per task; verify commit-completeness + clean-bytecode + full-suite before merge.

--- a/docs/superpowers/specs/2026-07-29-sase-slice-a-blocklist-design.md
+++ b/docs/superpowers/specs/2026-07-29-sase-slice-a-blocklist-design.md
@@ -1,0 +1,76 @@
+# SASE Slice A — STIX-Normalized IOC Blocklist (Design Spec)
+
+**Date**: 2026-07-29
+**Status**: Design approved; ready for implementation plan
+**Cross-references**:
+- SASE security design: `docs/superpowers/specs/2026-07-26-sase-sdwan-ziti-core-split.md` ("Detection→Block Feedback Loop")
+- Shared cache: `hub_api/cache/` (`CacheClient`, namespaces `sase:blocklist:*`, `sase:catcache:*`)
+- Existing feeds: `hub_api/modules/sase/security/feeds/` (real ingestion → `threat_indicators` table)
+
+## Goal
+
+Stand up the shared **detection→block store** the whole SASE loop depends on: a STIX-2.1-normalized IOC blocklist in Valkey that analysis adapters (Slice D) will WRITE, Inspection Points (future Go/Rust data plane) will READ and enforce on future traffic, and hub-api CURATES. Slice A seeds it from the **existing real `feeds/` ingestion** so it is useful immediately and Slices B–E plug into a ready store.
+
+## Scope (locked)
+
+- **In**: STIX normalizer (OASIS `stix2` lib), `BlocklistStore` over `CacheClient`, a curator that populates the store from the existing `threat_indicators` table, a Python `check()` read-API, and an enforcement-contract doc for the data plane.
+- **Out** (later slices / future): the Go/Rust Inspection Point enforcement itself (documented contract only); the analysis-adapter *writers* (Slice D); the category cache `sase:catcache:*` and SWG filtering (Slice B); enforcement *actions* and block pages (Slice B/C). Slice A stores "this IOC is malicious + provenance," NOT what to do about it (action = policy, decided at enforcement time).
+
+## Architecture — two representations, one source of truth
+
+1. **Canonical: STIX 2.1 Indicator** (via `stix2` lib) — interchange/audit format; the reason the SASE spec chose STIX (MISP/TAXII/feed interop). Persisted for audit; NOT read per-packet.
+2. **Denormalized: Valkey fast-index** — O(1) enforcement reads, keyed by IOC value:
+   - `sase:blocklist:ip:<ip>` · `sase:blocklist:domain:<domain>` · `sase:blocklist:url:<url-sha256>` · `sase:blocklist:hash:<sha256>`
+   - value = compact JSON `Verdict{ioc_type, value, severity, source, stix_id, first_seen, expiry}` (no action field — action is Slice-B policy).
+
+Data flow: `threat_indicators` (feeds, exists) → `curator` → `stix_normalizer` (canonical Indicator + `stix_id`) → `BlocklistStore.put` (compact Verdict into Valkey, dedup + TTL) → `BlocklistStore.check(ioc_type, value)` (read-API; the Go Inspection Point reads the same keys directly).
+
+## Components — `hub_api/modules/sase/security/blocklist/`
+
+- `models.py` — `@dataclass(slots=True) Verdict(ioc_type: str, value: str, severity: str, source: str, stix_id: str, first_seen: int, expiry: int|None)`; `IOCType` = {"ip","domain","url","hash"}; `Severity` = {"low","medium","high","critical"}.
+- `stix_normalizer.py` — `to_stix_indicator(ioc_type, value, *, severity, source, first_seen) -> stix2.Indicator` building the correct STIX pattern per type: `[ipv4-addr:value = '<ip>']`, `[domain-name:value = '<d>']`, `[url:value = '<u>']`, `[file:hashes.'SHA-256' = '<h>']`; `labels=["malicious-activity"]`, `confidence` from severity, `external_references` = the feed source. Returns the object (its `.id` is the `stix_id`).
+- `store.py` — `BlocklistStore(cache: CacheClient)`: `async put(verdict) -> None` (dedup: if an entry exists for the same IOC value, keep the higher severity / newer `first_seen`; set TTL from `expiry`), `async check(ioc_type, value) -> Verdict|None`, `async remove(ioc_type, value)`. All keys under the `sase:blocklist` namespace (URL keyed by `sha256(url)` to bound key length). `check` uses `fail_closed=False` (a cache blip must NOT block traffic — availability over catching one packet, per the out-of-band mandate; a missed lookup fails **open**).
+- `curator.py` — `BlocklistCurator(dal, store, normalizer)`: `async curate() -> CurationStats` reads active rows from `threat_indicators`, normalizes each, `put`s the Verdict, dedups, applies TTL/expiry, writes an audit summary; a `curate_one(indicator)` hook the feed-ingest path calls on new indicators. TTL default from indicator age / a configurable window; expired entries drop naturally (Valkey TTL) + a sweep prunes the canonical audit.
+- `api/blocklist.py` (optional, flag-gated) — a read-only admin endpoint `GET /api/v1/sase/blocklist/check?type=&value=` returning the verdict (for hub-webui / debugging). Response through a typed DTO (per the output-validation rule).
+
+## Feature flag & tier
+
+- Flag `tobogganing.sase.blocklist` — **community** (it extends the existing community `threat_feeds`); default OFF until validated. Registered in the sase module contract.
+- No new license entitlement (community).
+
+## Dependency
+
+- `stix2` (OASIS) — pin exact version with hash via `uv pip compile --generate-hashes` into `hub_api/requirements.{in,txt}`. Western/OASIS-maintained (supply-chain OK).
+
+## Enforcement contract (doc, `docs/architecture/sase-blocklist-enforcement-contract.md`)
+
+The Go/Rust Inspection Point (future) reads `sase:blocklist:*` directly from the shared Valkey (per-service key-prefix ACL, read-only on that prefix), checks each flow's IOCs (dest IP/domain, requested URL, downloaded file hash) against the store, and enforces on **future** traffic only — decoupled/async, **no per-request gRPC to hub-api**. The verdict→action mapping (drop/reject/soft-block/log-only) is **policy** resolved separately (Slice B). A cache miss/outage **fails open** (out-of-band mandate: never add latency, "allow a few through").
+
+## Error handling
+
+- `check` fails open on cache error (returns None → traffic allowed). `put`/`curate` fail soft (log + continue; a curation error must not crash feed ingestion). Namespace guard (`CacheClient`) rejects any write outside `sase:blocklist:*`. Invalid IOC (unparseable IP/hash) → skipped with a logged warning, never a crash.
+- Valkey at-rest encryption is the deployment baseline (same shared Valkey as the auth revocation store) — noted in Helm values, not code.
+
+## Testing
+
+- **Normalizer**: each IOC type → a valid `stix2.Indicator` with the correct pattern (assert `pattern` string + `stix2.parse` round-trips); severity→confidence mapping.
+- **Store**: `put`+`check` round-trip per IOC type; dedup keeps higher severity; TTL/expiry honored (put with short TTL → gone after); URL keyed by hash; namespace guard rejects cross-prefix; `check` fails open when cache unavailable (returns None, no raise).
+- **Curator**: seeded `threat_indicators` rows → `curate()` populates the store; two indicators for the same IOC → higher severity wins; expired indicator → not stored (or TTL'd); a malformed row is skipped without aborting the run; `CurationStats` counts.
+- **Read-API** (if built): `check` endpoint returns the verdict DTO; unknown IOC → 404/empty; flag OFF → 404/disabled.
+- Full-suite parity; ≥ current baseline; boot clean.
+
+## Sequencing (for the plan)
+
+1. `models.py` + `stix_normalizer.py` (+ pin `stix2`) — no store yet.
+2. `BlocklistStore` (`store.py`) on `CacheClient`.
+3. `BlocklistCurator` (`curator.py`) reading `threat_indicators`.
+4. Flag + optional read-API + sase contract registration.
+5. Enforcement-contract doc.
+
+Each an independently testable commit; a single feature branch (or a short stack). Curator depends on store; store depends on models/normalizer.
+
+## Notes
+
+- No change to the existing `feeds/` ingestion behavior — the curator *reads* `threat_indicators`; it does not alter how feeds populate that table.
+- The Valkey blocklist is the same shared instance/`CacheClient` as the auth revocation store — different namespace (`sase:blocklist:*` vs `auth:*`), enforced by the namespace guard.
+- Future: Slice D adapters call `curate_one`/`store.put` with adapter verdicts (Suricata/Strelka/CAPE); Slice B adds the category cache + action policy on top of the same store.


### PR DESCRIPTION
Design spec + 5-task plan for the first SASE security slice — the shared detection→block store.

- STIX 2.1 (OASIS `stix2` lib) canonical indicators + denormalized Valkey `sase:blocklist:*` fast-index over the `CacheClient` foundation.
- Curator seeds it from the EXISTING real `threat_indicators` feeds; `check()` fails OPEN (out-of-band mandate).
- Python store + read-API + Go/Rust enforcement contract doc; adapters (Slice D) + category filter (Slice B) plug in later.

Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)