### PR TITLE
docs(sase): Slice B + D specs + plans (SASE Wave 1)

### DIFF
--- a/docs/superpowers/plans/2026-08-06-sase-slice-b-swg.md
+++ b/docs/superpowers/plans/2026-08-06-sase-slice-b-swg.md
@@ -1,0 +1,215 @@
+# SASE Slice B — SWG Category Filter Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: superpowers:subagent-driven-development. Steps use checkbox (`- [ ]`). Executed by `penguin-python-dev` — PenguinTech Python conventions (async, `@dataclass(slots=True)`, type hints, structlog, penguin-dal, Alembic).
+
+**Goal:** Tier-1 SWG — categorized-domain radix lookup + per-tenant/user/group category→action policy, seeded from open category DBs on a daily schedule; Python builds/serves, data-plane enforces (contract).
+
+**Architecture:** Mirrors Slice A. `domain_categories` DB canonical + Valkey `sase:catcache:*` fast-index; a reverse-ordered `RadixTree` built from them, serialized and served (`GET /swg/radix`) for the data plane to pull daily; `SwgLookup` resolves domain→categories→`EnforcementAction` (unified enum) per tenant/user/group; fails **open**.
+
+**Tech Stack:** Python 3.13, `hub_api/cache/CacheClient`, penguin-dal, Alembic, Quart, `aiohttp` (existing), `hub_api/scheduler`.
+
+## Global Constraints
+
+- Spec: `docs/superpowers/specs/2026-08-06-sase-slice-b-swg-design.md` — authoritative.
+- Green gate: `python3 -m pytest hub_api/tests/` (baseline **923**, 0 fail) in **batches** (env kills >~120s); `create_app()` boots; `scripts/audit_imports.py --module sase --forbid sdwan,ziti` clean. Clean bytecode first.
+- **Commit-completeness (hard):** after each commit `git status --short` empty + `git show HEAD --stat` lists every file; `git check-ignore` every NEW file; after `git push` confirm `git log --oneline -1 origin/<branch>` == your SHA.
+- **`lookup` fails OPEN** (miss/cache-error → `allow`) — out-of-band mandate. Ingestion fails soft (per-source try/except; malformed line skipped, counted).
+- Unified `EnforcementAction` = {`allow`,`log_only`,`soft_block`,`block`,`drop`}; `isolate` reserved-not-implemented. Custom categories win on conflict; most-restrictive action wins among a domain's categories; scope precedence user>group>tenant.
+- Valkey writes confined to `sase:catcache:*` (CacheClient guard). Flag `tobogganing.sase.swg` — community, default OFF, gated via `@require_feature("sase","swg")`.
+- **No new pip dependency** — RadixTree implemented in-repo.
+- Alembic: read the current migration head at implementation time (`hub_api/migrations/versions/`), chain the new revs after it; declare in the sase `ModuleContract.migrations`.
+
+---
+
+## Task 1: `EnforcementAction` enum + SWG models
+
+**Files:** Create `hub_api/modules/sase/security/enforcement.py`, `hub_api/modules/sase/security/swg/__init__.py`, `swg/models.py`; Test `hub_api/tests/test_sase_swg_models.py`.
+
+**Interfaces:**
+- Produces: `class EnforcementAction(str, Enum)` = allow/log_only/soft_block/block/drop (+ `isolate` reserved, with a comment "reserved — not implemented"); `ACTION_SEVERITY` ordering (allow < log_only < soft_block < block < drop) for most-restrictive resolution; `DEFAULT_UNCATEGORIZED = EnforcementAction.allow`. `@dataclass(slots=True)` `DomainCategory`, `CategoryPolicy(... action: EnforcementAction ...)`, `LookupResult(domain, categories: tuple[str,...], action: EnforcementAction, matched_scope: str, uncategorized: bool)`.
+
+- [ ] **Step 1: Write failing test:**
+
+```python
+from hub_api.modules.sase.security.enforcement import EnforcementAction, ACTION_SEVERITY, most_restrictive
+
+def test_action_enum_values():
+    assert EnforcementAction.block.value == "block"
+    assert EnforcementAction.soft_block.value == "soft_block"
+
+def test_most_restrictive():
+    assert most_restrictive([EnforcementAction.allow, EnforcementAction.block, EnforcementAction.log_only]) == EnforcementAction.block
+    assert most_restrictive([EnforcementAction.drop, EnforcementAction.block]) == EnforcementAction.drop
+```
+
+- [ ] **Step 2: Run → FAIL.**
+- [ ] **Step 3: Implement** `enforcement.py` (enum, `ACTION_SEVERITY` dict, `most_restrictive(actions) -> EnforcementAction` picking the highest severity, `DEFAULT_UNCATEGORIZED`) + `swg/models.py` dataclasses. 2-3 line docstrings.
+- [ ] **Step 4: Run → PASS.** **Step 5: Green gate + commit.**
+
+---
+
+## Task 2: `RadixTree` (reverse-ordered domain trie)
+
+**Files:** Create `swg/radix.py`; Test `hub_api/tests/test_sase_swg_radix.py`.
+
+**Interfaces:**
+- Produces: `class RadixTree` with `insert(domain: str, categories: tuple[str,...]) -> None`, `lookup(domain: str) -> tuple[str,...]|None` (subdomain-covering: a node for `badsite.com` matches `a.b.badsite.com`), `serialize() -> bytes`, classmethod `deserialize(data: bytes) -> RadixTree`.
+
+- [ ] **Step 1: Write failing tests:**
+
+```python
+from hub_api.modules.sase.security.swg.radix import RadixTree
+
+def test_exact_and_subdomain_cover():
+    t = RadixTree(); t.insert("badsite.com", ("gambling",))
+    assert t.lookup("badsite.com") == ("gambling",)
+    assert t.lookup("a.b.badsite.com") == ("gambling",)   # subdomain covered
+    assert t.lookup("good.com") is None
+
+def test_more_specific_wins():
+    t = RadixTree(); t.insert("shop.com", ("shopping",)); t.insert("evil.shop.com", ("malware",))
+    assert set(t.lookup("evil.shop.com")) == {"malware"}   # most-specific node
+
+def test_serialize_roundtrip():
+    t = RadixTree(); t.insert("x.com", ("news",))
+    t2 = RadixTree.deserialize(t.serialize())
+    assert t2.lookup("a.x.com") == ("news",)
+```
+
+- [ ] **Step 2: Run → FAIL.**
+- [ ] **Step 3: Implement** — store domains reversed (`com.badsite`) as label-path in a nested-dict trie; `lookup` walks labels root→leaf and returns the categories of the **deepest** node marked terminal along the path (subdomain-covering + most-specific). `serialize`/`deserialize` via `json.dumps(...).encode()` (compact; the artifact the data plane pulls).
+- [ ] **Step 4: Run → PASS.** **Step 5: Green gate + commit.**
+
+---
+
+## Task 3: Category sources + ingestion + `domain_categories` (Alembic) + catcache
+
+**Files:** Create `swg/sources.py`, `swg/ingest.py`, `hub_api/migrations/versions/<next>_swg_domain_categories.py`; Test `hub_api/tests/test_sase_swg_ingest.py` (real-DAL).
+
+**Interfaces:**
+- Consumes: penguin-dal, `CacheClient` (`sase:catcache`), `DomainCategory` (T1).
+- Produces: `CATEGORY_SOURCES` list (name, url, license, `parse(text) -> Iterable[tuple[str, str]]` domain→category); `CategoryIngestManager(db, cache)` with `async ingest_source(source) -> IngestStats`, `async ingest_all() -> IngestStats`, `async upsert_custom(domain, category, tenant) -> None`. `@dataclass(slots=True) IngestStats(source, scanned, stored, skipped)`.
+
+- [ ] **Step 1:** Read `feeds/sources.py` + `feeds/manager.py` for the fetch/upsert/error-backoff pattern; read the current Alembic head + `0002_sase_firewall_rules.py` for the migration template.
+- [ ] **Step 2: Write the Alembic migration** — `domain_categories` (id, domain indexed, category, source, tenant nullable, updated_at; unique-ish on (domain,category,source,tenant)); chain `down_revision` = current head.
+- [ ] **Step 3: Write failing tests** (real-DAL, mirror `test_sase_feeds_realdal.py`):
+
+```python
+async def test_ingest_populates_categories(real_dal, cache):
+    mgr = CategoryIngestManager(real_dal, cache)
+    stats = await mgr.ingest_source(_fixture_source([("bad.com","gambling"),("x.com","news")]))
+    assert stats.stored == 2
+    # catcache written
+    assert await cache.get("sase:catcache", "bad.com") is not None
+
+async def test_custom_category_wins_on_conflict(real_dal, cache):
+    mgr = CategoryIngestManager(real_dal, cache)
+    await mgr.ingest_source(_fixture_source([("shop.com","shopping")]))
+    await mgr.upsert_custom("shop.com", "blocked-shopping", tenant="acme")
+    # both stored; radix build (T5) resolves custom-wins — here assert both rows present, source distinguishes
+    rows = await real_dal(real_dal.domain_categories.domain == "shop.com").select()
+    assert any(r.source == "custom" for r in rows)
+
+async def test_malformed_line_skipped_without_crash(real_dal, cache):
+    stats = await CategoryIngestManager(real_dal, cache).ingest_source(_fixture_source_with_bad_line())
+    assert stats.skipped >= 1   # run completed
+```
+
+- [ ] **Step 4: Run → FAIL.**
+- [ ] **Step 5: Implement** `sources.py` (the 6 feed sources w/ real URLs + parsers per license — UT1[CC]/blocklistproject[MIT]/cipher-oos/HaGeZi-OISD[CC0]/StevenBlack[MIT]/urlhaus-PhishTank[CC0]; each `parse()` yields domain→category) and `ingest.py` (fetch via aiohttp, upsert into `domain_categories` + write `sase:catcache:<domain>` = categories JSON; per-line try/except → skipped++; per-source try/except; `upsert_custom` with source="custom").
+- [ ] **Step 6: Run → PASS.** **Step 7: Green gate** (batch: new test + `test_sase_feeds*.py` untouched + migrations head test) **+ commit.**
+
+---
+
+## Task 4: `CategoryPolicy` manager + `category_policies` (Alembic)
+
+**Files:** Create `swg/policy.py`, `hub_api/migrations/versions/<next+1>_swg_category_policies.py`; Test `hub_api/tests/test_sase_swg_policy.py`.
+
+**Interfaces:**
+- Produces: `CategoryPolicyManager(db)` with `async set_policy(tenant, scope, scope_id, category, action) -> None`, `async get_policies(tenant) -> list[CategoryPolicy]`, `async resolve(tenant, categories, *, user_id=None, group_ids=()) -> tuple[EnforcementAction, str]` (returns action + matched_scope; user>group>tenant; `most_restrictive` among matched categories; default `DEFAULT_UNCATEGORIZED` if none).
+
+- [ ] **Step 1:** Alembic migration `category_policies` (id, tenant idx, scope, scope_id, category, action, created_at). `down_revision` = T3's rev.
+- [ ] **Step 2: Write failing tests:**
+
+```python
+async def test_resolve_scope_precedence(real_dal):
+    m = CategoryPolicyManager(real_dal)
+    await m.set_policy("acme","tenant",None,"gambling","block")
+    await m.set_policy("acme","user","u1","gambling","allow")
+    action, scope = await m.resolve("acme", ("gambling",), user_id="u1")
+    assert action == EnforcementAction.allow and scope == "user"   # user beats tenant
+
+async def test_resolve_most_restrictive_across_categories(real_dal):
+    m = CategoryPolicyManager(real_dal)
+    await m.set_policy("acme","tenant",None,"news","allow")
+    await m.set_policy("acme","tenant",None,"malware","block")
+    action, _ = await m.resolve("acme", ("news","malware"))
+    assert action == EnforcementAction.block
+
+async def test_resolve_unknown_category_defaults(real_dal):
+    action, scope = await CategoryPolicyManager(real_dal).resolve("acme", ("weird",))
+    assert action == EnforcementAction.allow and scope == "default"
+```
+
+- [ ] **Step 3: Run → FAIL. Step 4: Implement** `resolve` (query tenant's policies, filter to the domain's categories, pick most-specific scope then `most_restrictive` action). **Step 5: Run → PASS. Step 6: Green gate + commit.**
+
+---
+
+## Task 5: `SwgLookup` (radix + policy + cache, fail-open, uncategorized stub)
+
+**Files:** Create `swg/lookup.py`; Test `hub_api/tests/test_sase_swg_lookup.py`.
+
+**Interfaces:**
+- Consumes: `RadixTree` (T2), `CategoryPolicyManager` (T4), `CacheClient`, `IngestManager`'s `domain_categories`/catcache.
+- Produces: `SwgLookup(radix, policy_mgr, cache)` with `async lookup(domain, *, tenant, user_id=None, group_ids=()) -> LookupResult`; `build_radix(db) -> RadixTree` (custom-wins-on-conflict merge). A no-op `_enqueue_uncategorized(domain, tenant)` stub (logs "would enqueue for Slice-E").
+
+- [ ] **Step 1: Write failing tests:**
+
+```python
+async def test_categorized_domain_resolves_action(lookup_with_seeded_radix):
+    r = await lookup.lookup("a.badsite.com", tenant="acme")   # badsite.com→gambling, policy block
+    assert r.categories == ("gambling",) and r.action == EnforcementAction.block and not r.uncategorized
+
+async def test_uncategorized_uses_default_and_enqueues(lookup, monkeypatch):
+    called = monkeypatch-spy on _enqueue_uncategorized
+    r = await lookup.lookup("unknown.example", tenant="acme")
+    assert r.uncategorized and r.action == EnforcementAction.allow and called
+
+async def test_lookup_fails_open_on_cache_error(lookup_with_dead_cache):
+    r = await lookup.lookup("x.com", tenant="acme")
+    assert r.action == EnforcementAction.allow   # no raise
+```
+
+- [ ] **Step 2: Run → FAIL. Step 3: Implement** — `build_radix` reads `domain_categories`, merges custom-over-feed, inserts into `RadixTree`; `lookup` tries radix then `sase:catcache`; categories→`policy_mgr.resolve`; none→`uncategorized=True`+`DEFAULT_UNCATEGORIZED` (or tenant override)+`_enqueue_uncategorized`; ANY error → `LookupResult(action=allow)` (fail open). **Step 4: Run → PASS. Step 5: Green gate + commit.**
+
+---
+
+## Task 6: API + flag + contract registration + scheduler
+
+**Files:** Create `swg/api.py`, `swg/scheduler.py`; Modify `hub_api/modules/sase/__init__.py` (flag `tobogganing.sase.swg`, `Entitlement("sase.swg","community")`, blueprint, migrations list); Test `hub_api/tests/test_sase_swg_api.py`.
+
+**Interfaces:**
+- Produces: blueprint `sase_swg` `url_prefix="/swg"` — `GET /lookup?domain=` (`LookupResultDTO`), `GET /radix` (serialized artifact + version, `@require_machine_jwt("swg:read")`), `POST /categories` + `GET|PUT /policy` (`@require_scope("sase:write")`). `swg/scheduler.py` registers a daily category-refresh + radix-rebuild job via `register_job_handler`.
+
+- [ ] **Step 1: Write failing tests** — `lookup` returns exact `LookupResultDTO` fields; flag OFF → 402; `radix` needs machine-JWT `swg:read` (add `swg:read` to `CLUSTER_SCOPES` in `machine_claims.py`); policy write needs `sase:write`; invalid domain → 400.
+- [ ] **Step 2: Run → FAIL. Step 3: Implement** the blueprint (DTO-dataclass, `@require_feature("sase","swg")`, decorator stack per the blocklist api.py convention), register flag+entitlement+blueprint+migrations in the sase `module()`, add `swg:read` to the cluster machine scope set, and `scheduler.py` (register the daily job handler; the handler calls `ingest_all` + rebuilds the radix artifact into cache/store). **Step 4: Run → PASS. Step 5: Green gate** (batch: new test + `test_sase_module.py` + `test_registry.py` + `test_machine_jwt_issuance.py` (scope add)) + boot (blueprint mounts) **+ commit.**
+
+---
+
+## Task 7: Data-plane enforcement contract doc
+
+**Files:** Create `docs/architecture/sase-swg-enforcement-contract.md`.
+
+- [ ] **Step 1:** Document: the Inspection Point pulls `GET /api/v1/sase/swg/radix` daily (freshclam cadence, machine-JWT `swg:read`), loads it in-memory, does inline O(k) reverse-domain lookup per request → categories → resolves `EnforcementAction` (unified enum) via cached policy, enforces (allow/log_only pass; soft_block interstitial; block RST/403+page; drop silent), **fails open** on miss. Uncategorized → tenant default + async enqueue to Slice-E (future). Action→page-serving is Slice-C. Commit.
+
+---
+
+## Self-Review
+
+- **Spec coverage:** enum→T1; radix→T2; ingestion+catcache+domain_categories→T3; policy→T4; lookup+fail-open+uncategorized-stub→T5; API+flag+scheduler→T6; contract→T7; custom-wins→T3/T5; scope precedence + most-restrictive→T4. All covered.
+- **Placeholders:** none — the uncategorized enqueue is an explicit no-op stub (Slice E), not a TODO.
+- **Type consistency:** `EnforcementAction`, `most_restrictive`, `RadixTree.{insert,lookup,serialize,deserialize}`, `CategoryIngestManager`, `CategoryPolicyManager.resolve`, `SwgLookup.lookup`, `LookupResult(DTO)` — consistent across tasks.
+
+## Execution
+
+Sequential (2→5 build on each other; 6 needs all). Single feature branch `feature/sase-swg` off release. Independent of Slice D → runs in parallel (Wave 1). `penguin-python-dev` per task; verify commit-completeness + clean-bytecode + full-suite before merge.

--- a/docs/superpowers/plans/2026-08-06-sase-slice-d-adapters.md
+++ b/docs/superpowers/plans/2026-08-06-sase-slice-d-adapters.md
@@ -1,0 +1,94 @@
+# SASE Slice D — Analysis Adapters Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: superpowers:subagent-driven-development. Steps use checkbox (`- [ ]`). Executed by `penguin-python-dev` (Python adapters) + `k8s-manifest-builder` (Helm sub-charts). PenguinTech conventions.
+
+**Goal:** Per-tool adapters (Suricata/Zeek/Strelka/CAPE/Arkime) that parse native output → normalize IOCs to STIX → write to the existing Slice-A `BlocklistStore`; tools ship as optional off-by-default Helm sub-charts. Strictly out-of-band.
+
+**Architecture:** `adapters/` package: an `AnalysisAdapter` base + per-tool parsers emitting `AdapterHit`s; `ingest()` reuses the Slice-A write path (`to_stix_indicator → Verdict → BlocklistStore.put`); a poller loop (mirrors `feeds/manager.py`); flag-gated; Helm sub-charts default false.
+
+**Tech Stack:** Python 3.13, `hub_api/modules/sase/security/blocklist/` (Slice A), `CacheClient`, `aiohttp` (existing), `hub_api/scheduler`, Helm.
+
+## Global Constraints
+
+- Spec: `docs/superpowers/specs/2026-08-06-sase-slice-d-adapters-design.md` — authoritative.
+- Green gate: `python3 -m pytest hub_api/tests/` (baseline **923**, 0 fail) in batches; `create_app()` boots; `scripts/audit_imports.py --module sase --forbid sdwan,ziti` clean. Clean bytecode first.
+- **Commit-completeness (hard):** `git status --short` empty + `git show HEAD --stat` after each commit; `git check-ignore` new files; after push confirm origin SHA matches.
+- **Every adapter is fail-soft**: malformed input → `skipped++`, never raises/aborts; a tool unreachable → logged, retried next poll; NOTHING touches live traffic (out-of-band — read side-channels only).
+- Reuse the Slice-A write path verbatim: `to_stix_indicator(ioc_type, value, severity=, source=, first_seen=)` → `Verdict(...)` → `await BlocklistStore(cache).put(verdict)`. `source` = the tool name. `ioc_type ∈ ("ip","domain","url","hash")`, `severity ∈ ("low","medium","high","critical")`.
+- Flag `tobogganing.sase.adapters` — community, default OFF, gated via `@require_feature` where an API surface exists (adapters are mostly background — the flag gates the poller registration).
+- Parsers pure-Python (json/csv) — **no new pip dep**; Strelka/CAPE via `aiohttp` if needed.
+- Helm: use `authoring-helm-charts` skill; each tool `condition: <tool>.enabled` default false; securityContext per standards (Suricata NET_ADMIN/NET_RAW = documented ROOT/cap exception).
+
+---
+
+## Task 1: Adapter base + config
+
+**Files:** Create `hub_api/modules/sase/security/adapters/__init__.py`, `adapters/base.py`, `adapters/config.py`; Test `hub_api/tests/test_sase_adapters_base.py`.
+
+**Interfaces:**
+- Produces: `@dataclass(slots=True) AdapterHit(ioc_type, value, severity, first_seen, detail)`; `@dataclass(slots=True) AdapterStats(source, scanned, stored, skipped)`; `class AnalysisAdapter(ABC)` with `source: str`, `abstract parse(raw) -> Iterable[AdapterHit]`, concrete `async ingest(raw, store) -> AdapterStats` (parse → `to_stix_indicator` → `Verdict` → `store.put`; per-hit try/except → skipped++); `AdapterConfig` reading per-tool enabled/endpoint from env (each default disabled).
+
+- [ ] **Step 1:** Read `blocklist/curator.py::curate_one` for the exact normalize→Verdict→put sequence to reuse.
+- [ ] **Step 2: Write failing test** — a `_StubAdapter(parse returns 2 hits)`; `await stub.ingest(raw, store)` → `stats.stored == 2` and `store.check` finds them with `source==stub.source`; a hit that raises in normalization → `skipped++`, run completes.
+- [ ] **Step 3: Run → FAIL. Step 4: Implement** base (the `ingest` template calling the Slice-A write path) + config. **Step 5: Run → PASS. Step 6: Green gate + commit.**
+
+---
+
+## Task 2: Suricata EVE adapter (the live one)
+
+**Files:** Create `adapters/suricata.py`; Test `hub_api/tests/test_sase_adapters_suricata.py` (with a fixture EVE JSON line).
+
+**Interfaces:**
+- Produces: `SuricataAdapter(AnalysisAdapter)` `source="suricata"`; `parse(raw: str)` handles newline-delimited EVE JSON, extracts from `alert` events: dest IP (`dest_ip`→ip), `tls.sni`/`http.hostname`→domain, `http.url`→url, `fileinfo.sha256`→hash; severity from `alert.severity` (1→critical,2→high,3→medium, else low).
+
+- [ ] **Step 1: Write failing tests** — a fixture EVE alert line with dest_ip + http.hostname → 2 hits (ip + domain) with correct severity; a fileinfo event with sha256 → hash hit; a non-alert event (`event_type:"flow"`) → 0 hits; a malformed line → skipped, no raise; `ingest` writes them to the store.
+- [ ] **Step 2: Run → FAIL. Step 3: Implement** the EVE parser. **Step 4: Run → PASS. Step 5: Green gate + commit.**
+
+---
+
+## Task 3: Zeek / Strelka / CAPE / Arkime adapters
+
+**Files:** Create `adapters/{zeek,strelka,cape,arkime}.py`; Test `hub_api/tests/test_sase_adapters_others.py` (fixtures per tool).
+
+**Interfaces:**
+- Produces: `ZeekAdapter` (source="zeek", parses notice.log JSON/TSV → ip/domain), `StrelkaAdapter` (source="strelka", YARA match + file sha256 → hash), `CapeAdapter` (source="cape", verdict malscore + sample sha256 + contacted hosts → hash/ip/domain), `ArkimeAdapter` (source="arkime", tagged session → ip/domain). All subclass `AnalysisAdapter`.
+
+- [ ] **Step 1: Write failing tests** — one fixture per tool → correct `AdapterHit`s (ioc_type/value/severity); malformed → skipped no-raise; `ingest` → store populated with the right `source`. (Fixtures are small representative captures — hand-author from each tool's documented output shape.)
+- [ ] **Step 2: Run → FAIL. Step 3: Implement** the 4 parsers behind the shared base. **Step 4: Run → PASS. Step 5: Green gate + commit.**
+
+---
+
+## Task 4: Poller + scheduler/flag + contract registration
+
+**Files:** Create `adapters/poller.py`; Modify `hub_api/modules/sase/__init__.py` (flag `tobogganing.sase.adapters`, `Entitlement("sase.adapters","community")`; register the poller job/handler); Test `hub_api/tests/test_sase_adapters_poller.py`.
+
+**Interfaces:**
+- Produces: `AdapterPoller(adapter, reader, store, interval)` — `async run_once()` (read new output via `reader`, `adapter.ingest`), `async loop()` (interval, error-backoff, mirror `feeds/manager.py`); a `register(...)` wiring pollers for enabled tools only (config-gated). `reader` = a callable returning new raw output (EVE log tail / API poll).
+
+- [ ] **Step 1: Write failing tests** — `run_once` with a stub reader returning a fixture EVE line → store populated; a reader that raises → caught, `run_once` returns stats with 0 stored (no crash); poller only registers for tools with `enabled=True` in config; flag OFF → poller not registered.
+- [ ] **Step 2: Run → FAIL. Step 3: Implement** poller + register flag/entitlement in the sase `module()` + wire the poller registration behind the flag + per-tool config. **Step 4: Run → PASS. Step 5: Green gate** (batch: new test + `test_sase_module.py` + `test_registry.py`) + boot **+ commit.**
+
+---
+
+## Task 5: Optional Helm sub-charts (off-by-default) — `k8s-manifest-builder`
+
+**Files:** Modify `k8s/helm/tobogganing/Chart.yaml` (+`dependencies:` for the 5 tools, each `condition: <tool>.enabled`), `values.yaml` (`<tool>.enabled: false`), create `charts/` stubs; docs note the ROOT/cap exception for Suricata.
+
+- [ ] **Step 1:** Dispatch `k8s-manifest-builder`: add the first `dependencies:` block (Suricata/Zeek/Arkime/Strelka/CAPE), each `condition: <tool>.enabled` default **false** in values.yaml; sub-chart stubs (or digest-pinned upstream refs) under `charts/`; securityContext per standards; Suricata's NET_ADMIN/NET_RAW as a documented `ROOT EXCEPTION (approved)`. Verify `helm lint` + `helm template --set suricata.enabled=true` renders it and default renders nothing for the tools.
+- [ ] **Step 2: Commit.**
+
+---
+
+## Task 6: (folded into T2/T3 fixtures) — n/a. Contract note
+
+The enforcement/read side is Slice A's contract (`sase-blocklist-enforcement-contract.md`) — D is write-only into that store, so no new data-plane contract doc is needed. Add a short `docs/architecture/sase-adapters.md` note describing the mirror→tool→adapter→blocklist flow + that everything is out-of-band. (Optional; fold into T4 commit if small.)
+
+## Self-Review
+
+- **Spec coverage:** base+config→T1; Suricata→T2; Zeek/Strelka/CAPE/Arkime→T3; poller+flag+contract→T4; Helm sub-charts→T5; out-of-band + fail-soft everywhere. All covered.
+- **Placeholders:** none — each adapter is a real parser tested against a fixture.
+- **Type consistency:** `AdapterHit`, `AdapterStats`, `AnalysisAdapter.{parse,ingest}`, `AdapterPoller` — consistent; write path matches Slice-A `to_stix_indicator`/`Verdict`/`BlocklistStore.put`.
+
+## Execution
+
+Sequential (2,3 need 1; 4 needs 1-3). Single feature branch `feature/sase-adapters` off release. **Disjoint from Slice B** → parallel (Wave 1). `penguin-python-dev` for T1-4; `k8s-manifest-builder` for T5. Verify commit-completeness + clean-bytecode + full-suite before merge.

--- a/docs/superpowers/specs/2026-08-06-sase-slice-b-swg-design.md
+++ b/docs/superpowers/specs/2026-08-06-sase-slice-b-swg-design.md
@@ -1,0 +1,99 @@
+# SASE Slice B — SWG Tier-1 Category Filter + Enforcement Actions (Design Spec)
+
+**Date**: 2026-08-06
+**Status**: Design approved; ready for implementation plan
+**Cross-references**:
+- SASE security design: `docs/superpowers/specs/2026-07-26-sase-sdwan-ziti-core-split.md` ("URL / Domain Category Filtering", "Enforcement Actions")
+- Slice A blocklist (merged): `hub_api/modules/sase/security/blocklist/`
+- Shared cache: `hub_api/cache/` (`CacheClient`, namespace `sase:catcache:*`)
+- Feeds ingestion pattern: `hub_api/modules/sase/security/feeds/manager.py`
+
+## Goal
+
+Tier-1 Secure Web Gateway: categorized-domain lookup (O(k) radix) + a per-tenant/user/group **category→action** policy, seeded from open category databases on a freshclam-style daily schedule. The fast inline tier (~95% of traffic). Mirrors Slice A's shape — **Python ingests + builds + serves + exposes a `lookup` API; the hot-path inline lookup + enforcement is a documented data-plane contract**. The AI Tier-2 for uncategorized domains is **Slice E** (B only tags `Uncategorized`, applies the tenant default, and leaves an enqueue hook).
+
+## Scope (locked)
+
+- **In**: `EnforcementAction` enum (shared; C reuses), category-DB ingestion (extend feeds machinery), `domain_categories` store (DB canonical + Valkey `sase:catcache:*` fast-index), reverse-ordered radix builder + serializable artifact, custom categories (admin-defined, win on conflict), `CategoryPolicy` (category→action, per tenant/user/group), freshclam daily scheduler, `lookup` + `radix artifact` APIs, data-plane enforcement contract doc.
+- **Out** (later slices): the inline data-plane enforcement itself (contract only); the AI Tier-2 categorizer (Slice E — B leaves the `Uncategorized`→enqueue hook); block-page rendering + routing (Slice C — B's action just names what fires); analysis adapters (Slice D).
+
+## Action model (locked)
+
+**One unified `EnforcementAction` enum**, in `hub_api/modules/sase/security/enforcement.py` (shared so Slice C + the data-plane contract reference one field):
+
+| action | meaning |
+|--------|---------|
+| `allow` | permit |
+| `log_only` | permit + record (monitor/baseline) |
+| `soft_block` | bypassable interstitial ("risky site", acknowledge to continue) — spec's "warn" |
+| `block` | deny with an active response (TCP RST / HTTP 403 + block page) — spec's "reject" |
+| `drop` | silently drop, no response to client |
+
+`isolate` (route to sandboxed/segmented access) is **deferred** — it needs data-plane network segmentation that doesn't exist yet; reserved as a future enum member, not implemented.
+
+## Components — `hub_api/modules/sase/security/swg/`
+
+- `hub_api/modules/sase/security/enforcement.py` (shared) — `class EnforcementAction(str, Enum)` with the 5 members above; `DEFAULT_UNCATEGORIZED = EnforcementAction.allow` (tenant may override to `block` = fail-closed).
+- `swg/models.py` — `@dataclass(slots=True) DomainCategory(domain, categories: tuple[str,...], source, updated_at)`; `@dataclass(slots=True) CategoryPolicy(id, tenant, scope, scope_id, category, action: EnforcementAction, created_at)` (`scope` ∈ {"tenant","group","user"}); `@dataclass(slots=True) LookupResult(domain, categories, action, matched_scope, uncategorized: bool)`.
+- `swg/sources.py` — category feed source registry (URL + license + parser) for UT1[CC], blocklistproject[MIT], cipher-oos, HaGeZi/OISD[CC0], StevenBlack[MIT], urlhaus/PhishTank[CC0]. Each maps its lists → `(domain, category)` pairs. Mirrors `feeds/sources.py`.
+- `swg/ingest.py` — `CategoryIngestManager(db)` — extends the feeds asyncio-loop pattern (`feeds/manager.py`): per-source daily fetch → upsert into `domain_categories` (DB) + write `sase:catcache:*` fast-index entries. Custom categories (admin-defined via API) upserted with a `source="custom"` that **wins on conflict** during radix build.
+- `swg/radix.py` — `RadixTree` reverse-ordered domain trie (`com.badsite.gambling`): `insert(domain, categories)`, `lookup(domain) -> categories|None` (O(k), subdomain-covering — a match on `com.badsite` covers `x.badsite.com`), `serialize() -> bytes` / `deserialize(bytes)`. `build_from_store(db) -> RadixTree`.
+- `swg/policy.py` — `CategoryPolicyManager(db)` — CRUD for `CategoryPolicy` (tenant-scoped); `resolve(tenant, categories, *, user_id, group_ids) -> EnforcementAction` (most-specific scope wins: user > group > tenant; among a domain's categories, the most-restrictive action wins; custom-category policy overrides).
+- `swg/lookup.py` — `SwgLookup(radix, policy_mgr, cache)` — `async lookup(domain, *, tenant, user_id, group_ids) -> LookupResult`: radix (or `sase:catcache:*`) → categories; if none → `uncategorized=True` + tenant default action + (Slice-E) enqueue hook (a no-op stub in B); else `policy_mgr.resolve(...)`. Fails **open** (miss/cache-error → `allow`) per the out-of-band mandate.
+- `swg/api.py` — blueprint `url_prefix="/swg"`:
+  - `GET /api/v1/sase/swg/lookup?domain=` → `LookupResultDTO` (typed, exact fields) — `@require_tenant` + `@require_scope("sase:read")` + `@require_feature("sase","swg")`.
+  - `GET /api/v1/sase/swg/radix` → the serialized radix artifact + `version`/etag — `@require_machine_jwt("swg:read")` (the data plane pulls this daily).
+  - `POST /api/v1/sase/swg/categories` (custom category upsert) + `PUT/GET /api/v1/sase/swg/policy` (category→action policy) — `@require_scope("sase:write")` + governance.
+- `swg/scheduler.py` — register a freshclam-style daily job (via `hub_api/scheduler` `register_job_handler` or the feeds asyncio loop) that refreshes category feeds + rebuilds the radix artifact. Same daily cadence covers A's threat feeds + future ClamAV.
+
+## Alembic
+
+New migration (next sequential rev after the current head — read the head at implementation time, do not hardcode): tables `domain_categories` (domain PK-ish, categories, source, tenant nullable for global vs custom, updated_at; indexed on domain + source) and `category_policies` (id, tenant, scope, scope_id, category, action, created_at; indexed on tenant + category). Declared in the sase `ModuleContract.migrations`.
+
+## Flags & tier
+
+- Flag `tobogganing.sase.swg` — **community** (SWG is core product per the ZScaler-alternative positioning); default OFF until validated. Registered in the sase `module()` contract with `Entitlement("sase.swg","community")`.
+- Optional commercial feed (spec) = Enterprise — **out of scope** for this slice (a future entitlement).
+
+## Dependencies
+
+- A pure-Python radix/trie: **implement in-repo** (`swg/radix.py`) rather than add a dependency — the structure is simple (reverse-ordered domain trie) and avoids a supply-chain add; the spec's LMDB/Cuckoo alternatives are noted as future scaling, not needed now.
+- Category feed fetching reuses the existing `aiohttp` already in feeds. No new external dependency.
+
+## Data flow
+
+`category DBs` → `CategoryIngestManager` (daily) → `domain_categories` (DB) + `sase:catcache:*` (Valkey) → `RadixTree.build_from_store` → serialized artifact (`GET /swg/radix`, data plane pulls daily) + `SwgLookup` (API + the same lookup the data plane does inline). Policy: `category → EnforcementAction` resolved per tenant/user/group at lookup time.
+
+## Error handling
+
+- `lookup` fails **open** (`allow`) on radix miss or cache error — never add latency (out-of-band mandate; "allow a few through"). Custom categories win on conflict; most-restrictive action wins among a domain's categories.
+- Ingestion fails soft (per-source try/except + error backoff, mirror feeds) — one bad feed never aborts the run or crashes the app. Malformed feed lines skipped with a logged count.
+- Namespace guard (`CacheClient`) confines writes to `sase:catcache:*`.
+- Uncategorized → tenant default (fail-open `allow` or fail-closed `block`); the Slice-E enqueue hook is a no-op stub in B (logs "would enqueue").
+
+## Testing
+
+- **Radix**: insert + subdomain-covering lookup (`com.badsite` covers `a.b.badsite.com`); serialize→deserialize round-trip; custom category overrides a feed category; miss → None.
+- **Ingest**: fixture category lists → `domain_categories` populated + `sase:catcache:*` written; custom category upsert wins on conflict; malformed line skipped without aborting; per-source failure isolated.
+- **Policy**: `resolve` — user scope beats group beats tenant; most-restrictive action among multiple categories; custom-category policy override; unknown category → tenant default.
+- **Lookup**: categorized domain → categories + resolved action; uncategorized → tenant default + enqueue-hook called (stub); fail-open on cache error (returns `allow`, no raise).
+- **API**: `lookup` returns the exact DTO field set; flag OFF → 402 (house `@require_feature` convention); `radix` artifact requires machine-JWT `swg:read`; custom-category/policy write requires `sase:write`; invalid domain → 400.
+- Full-suite parity ≥ current baseline; boot clean; `audit_imports --module sase` clean.
+
+## Sequencing (for the plan)
+
+1. `enforcement.py` (shared enum) + `swg/models.py`.
+2. `swg/radix.py` (RadixTree, serialize).
+3. `swg/sources.py` + `swg/ingest.py` (+ Alembic `domain_categories`) + `sase:catcache:*`.
+4. `swg/policy.py` (+ Alembic `category_policies`).
+5. `swg/lookup.py` (ties radix + policy + cache; fail-open; uncategorized stub).
+6. `swg/api.py` + flag + contract registration + `swg/scheduler.py`.
+7. Data-plane enforcement contract doc.
+
+Single feature branch `feature/sase-swg` (or short stack). Independent of Slice D (disjoint module) → **implements in parallel with D (Wave 1)**.
+
+## Notes
+
+- No change to Slice A / existing feeds behavior. `sase:catcache:*` and `sase:blocklist:*` share the one Valkey via the namespace-guarded `CacheClient`.
+- The `EnforcementAction` enum is the seam Slice C (block pages, per-source routing) and the data-plane contract both key off — defining it here avoids C re-deriving it.
+- Slice E (AI Tier-2) plugs into the `uncategorized` hook + writes back to `sase:catcache:*` + the radix — B leaves that hook and the write-back path ready.

--- a/docs/superpowers/specs/2026-08-06-sase-slice-d-adapters-design.md
+++ b/docs/superpowers/specs/2026-08-06-sase-slice-d-adapters-design.md
@@ -1,0 +1,76 @@
+# SASE Slice D — Out-of-Band Analysis Adapters (Design Spec)
+
+**Date**: 2026-08-06
+**Status**: Design approved; ready for implementation plan
+**Cross-references**:
+- SASE security design: `docs/superpowers/specs/2026-07-26-sase-sdwan-ziti-core-split.md` ("SASE Traffic-Mirror Hooks", "Detection→Block Feedback Loop")
+- Slice A blocklist write-side (merged): `hub_api/modules/sase/security/blocklist/` (`to_stix_indicator`, `Verdict`, `BlocklistStore.put`, `BlocklistCurator.curate_one`)
+- Existing Go mirror: `services/hub-router/proxy/mirror/manager.go` (VXLAN/GRE/ERSPAN + Suricata EVE emission)
+
+## Goal
+
+Turn the out-of-band analysis tools' output into blocklist verdicts. Each tool (Suricata, Zeek, Strelka, CAPE, Arkime) gets an **adapter** that parses its native output → normalizes IOCs to STIX 2.1 → writes to the **existing** Slice-A `BlocklistStore` (`sase:blocklist:*`). The tools ship as **optional, off-by-default Helm sub-charts**. Strictly **out-of-band** — adapters read a mirror/log side-channel; nothing here touches the live traffic path (zero added latency; "allow a few through").
+
+## Scope (locked)
+
+- **In**: an adapter base class + framework; per-tool parsers (Suricata EVE, Zeek notice, Strelka YARA/file-scan, CAPE verdict, Arkime session-flag) that emit `Verdict`s into `BlocklistStore`; a poller/scheduler (mirror the feeds asyncio loop / register a scheduler job); optional off-by-default Helm sub-charts for the 5 tools (establish the `dependencies:` + `condition:` pattern — none exists yet); adapter config (mirror destinations, tool endpoints).
+- **Out**: changing the Go mirror (`hub-router`) — it already emits to Suricata; D consumes the side-channel; the block-list *enforcement* (data-plane, Slice A's contract); the category/SWG path (Slice B).
+
+## Architecture
+
+The Go mirror already duplicates traffic out-of-band to Suricata (EVE JSON → a log volume with **no consumer today** — that volume is the seam). Adapters run as **sidecars / scheduled pollers** in hub-api's plane: each tails/polls its tool's output on an interval, extracts IOCs (malicious IP/domain/URL/file-hash), and calls the Slice-A write path. Decoupled + async — no inline coupling to live traffic.
+
+**Write path (per the recon, reused verbatim):**
+`normalize hit → to_stix_indicator(ioc_type, value, severity=…, source="suricata"|"zeek"|"strelka"|"cape"|"arkime", first_seen=ts) → Verdict(ioc_type, value, severity, source, stix_id=ind.id, first_seen, expiry) → await BlocklistStore(cache).put(verdict)`. Optionally also upsert into `threat_indicators` (as feeds do) so the existing curator re-derives it and hub-api curates/audits centrally.
+
+## Components — `hub_api/modules/sase/security/adapters/`
+
+- `adapters/base.py` — `class AnalysisAdapter(ABC)`: `source: str`; `abstract parse(raw) -> Iterable[AdapterHit]`; concrete `async ingest(raw, store) -> AdapterStats` (parse → normalize → `store.put`, per-hit try/except → skipped++, best-effort). `@dataclass(slots=True) AdapterHit(ioc_type, value, severity, first_seen, detail)`; `@dataclass(slots=True) AdapterStats(source, scanned, stored, skipped)`.
+- `adapters/suricata.py` — `SuricataAdapter` — parses **EVE JSON** lines; extracts IOCs from `alert` events (dest IP, TLS/HTTP hostname → domain, http.url → url; `fileinfo.sha256` → hash); maps Suricata alert severity → `SEVERITIES`. (The one with a live data source today.)
+- `adapters/zeek.py` — `ZeekAdapter` — parses Zeek `notice.log` / intel hits (TSV or JSON) → IOCs.
+- `adapters/strelka.py` — `StrelkaAdapter` — parses Strelka scan events (YARA matches + file `sha256`) → hash IOCs (+ severity from match).
+- `adapters/cape.py` — `CapeAdapter` — parses CAPE sandbox verdicts (malscore/verdict + sample sha256 + contacted hosts) → hash + ip/domain IOCs.
+- `adapters/arkime.py` — `ArkimeAdapter` — parses Arkime session flags/tags → ip/domain IOCs.
+- `adapters/poller.py` — `AdapterPoller(adapter, source_reader, store)` — an interval loop (mirror `feeds/manager.py`): read new tool output (EVE log tail / Zeek log / Strelka|CAPE|Arkime API) → `adapter.ingest`. Registered as a scheduler job OR an always-on sidecar; off unless the tool's flag is on.
+- `adapters/config.py` — per-tool config (endpoint/log path/enabled) from env; each tool default **disabled**.
+
+## Helm sub-charts (establish the pattern — greenfield)
+
+Under `k8s/helm/tobogganing/` add the first `dependencies:` block in `Chart.yaml`, one entry per tool, each `condition: <tool>.enabled` defaulting **false** in `values.yaml`; sub-chart stubs (or upstream chart refs, digest-pinned) under `charts/`. Each tool's Deployment carries securityContext per standards (Suricata needs `NET_ADMIN`/`NET_RAW` — a documented ROOT/cap exception). Use the `authoring-helm-charts` skill. **Off by default**; the baseline product ships without them.
+
+## Flags & tier
+
+- Flag `tobogganing.sase.adapters` — **community** (IDS/threat detection is community per the ZScaler-alternative positioning + the existing Suricata/IDS community entitlement); default OFF. Per-tool enable via config, not per-tool flags. Registered in the sase `module()` contract with `Entitlement("sase.adapters","community")`.
+
+## Dependencies
+
+- Parsers are pure Python (json/csv) — **no new pip dependency** for Suricata/Zeek/Arkime. Strelka/CAPE API clients: if a maintained Western client lib exists, pin it with hashes; otherwise call their REST APIs via existing `aiohttp` (preferred — avoids a dependency). Decide per-tool at implementation; default to `aiohttp`.
+
+## Error handling
+
+- Every adapter is **best-effort + fail-soft**: a malformed line/event → `skipped++`, never aborts the run or crashes; a tool being unreachable → logged + retried on the next poll (never blocks). `store.put` is already best-effort (Slice A). Nothing here can affect live traffic (out-of-band mandate — adapters only read side-channels).
+- Adapter writes go through the Slice-A namespace-guarded store (`sase:blocklist:*` only).
+
+## Testing
+
+- **Each adapter**: fixture tool output (a captured EVE JSON line, a Zeek notice row, a Strelka YARA event, a CAPE verdict JSON, an Arkime session) → correct `AdapterHit`s (right ioc_type/value/severity); malformed input → `skipped`, no raise; empty → zero hits.
+- **Write path**: `adapter.ingest(fixture, store)` populates the blocklist store (`store.check` returns the verdict with `source="suricata"` etc.); severity mapping correct.
+- **Poller**: an interval loop calls `ingest` on new output; a tool-unreachable read is caught + retried (no crash).
+- **Helm**: `helm lint` + `helm template --set <tool>.enabled=true` renders the sub-chart; default (flags off) renders nothing for the tools; securityContext present; digests pinned.
+- Full-suite parity; boot clean; `audit_imports --module sase` clean.
+
+## Sequencing (for the plan)
+
+1. `adapters/base.py` (base + `AdapterHit`/`AdapterStats`) + `adapters/config.py`.
+2. `adapters/suricata.py` (the live one — EVE parser) — fully real + tested.
+3. `adapters/{zeek,strelka,cape,arkime}.py` — parsers behind the same base, fixture-tested (can be one task or split).
+4. `adapters/poller.py` + scheduler/sidecar registration + flag + contract registration.
+5. Optional Helm sub-charts (off-by-default) — `authoring-helm-charts` skill.
+
+Single feature branch `feature/sase-adapters` off release. **Disjoint from Slice B** (`adapters/` vs `swg/`) → **implements in parallel with B (Wave 1)**.
+
+## Notes
+
+- No change to the Go mirror or Slice A. D is purely additive — new `adapters/` package + optional sub-charts.
+- The Suricata adapter is the immediately-useful one (live EVE output exists); the others become useful when their sub-charts are enabled.
+- Central curation/audit stays in hub-api (Slice A's curator) — adapters can optionally also write `threat_indicators` so the curator re-derives + dedups + TTLs centrally.


### PR DESCRIPTION
Specs + task-by-task plans for the two independent SASE Wave-1 slices (both only need merged Slice A, disjoint modules → implement in parallel).

- **Slice B** (`swg/`): Tier-1 SWG — radix category filter, unified `EnforcementAction` {allow,log_only,soft_block,block,drop} (isolate deferred), category-DB ingestion (UT1[CC]+MIT/CC0 sources), category→action policy (tenant/group/user), `sase:catcache:*`, freshclam daily scheduler, lookup+radix APIs, data-plane contract. 7 tasks.
- **Slice D** (`adapters/`): out-of-band Suricata/Zeek/Strelka/CAPE/Arkime adapters → normalize IOCs → Slice-A `BlocklistStore.put`; poller; optional off-by-default Helm sub-charts. 5 tasks.

Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)