### PR TITLE
fix(sase): SWG catcache CacheClient signature (namespace guard)

### DIFF
--- a/hub_api/modules/sase/security/swg/ingest.py
+++ b/hub_api/modules/sase/security/swg/ingest.py
@@ -267,8 +267,7 @@ class CategoryIngestManager:
 
             if all_categories:
                 # Write to cache: sase:catcache:<domain> = JSON array
-                cache_key = f"sase:catcache:{domain}"
                 cache_value = json.dumps(sorted(list(all_categories)))
-                await self.cache.set(cache_key, cache_value, ttl=86400)  # 24hr TTL
+                await self.cache.set("sase:catcache", domain, value=cache_value, ttl_seconds=86400)  # 24hr TTL
         except Exception as e:
             logger.debug("write_cache_failed", domain=domain, error=str(e))

--- a/hub_api/modules/sase/security/swg/lookup.py
+++ b/hub_api/modules/sase/security/swg/lookup.py
@@ -120,8 +120,7 @@ class SwgLookup:
             Tuple of categories, or None.
         """
         try:
-            cache_key = f"sase:catcache:{domain}"
-            cached_value = await self.cache.get(cache_key)
+            cached_value = await self.cache.get("sase:catcache", domain, fail_closed=False)
 
             if cached_value:
                 try:

--- a/hub_api/tests/test_sase_swg_ingest.py
+++ b/hub_api/tests/test_sase_swg_ingest.py
@@ -1,9 +1,12 @@
 """Tests for SASE SWG category ingestion."""
 from __future__ import annotations
 
+import json
 import pytest
 
 from hub_api.modules.sase.security.swg.ingest import CategoryIngestManager, IngestStats
+from hub_api.cache.client import CacheClient
+from unittest.mock import MagicMock, AsyncMock
 
 
 class SimpleSource:
@@ -65,3 +68,35 @@ def test_malformed_line_skipped_without_crash() -> None:
 
     assert stats.skipped >= 1
     assert stats.stored >= 1
+
+
+@pytest.mark.asyncio
+async def test_catcache_write_with_real_client() -> None:
+    """Test category ingestion cache write using real CacheClient.
+
+    regression: swg catcache CacheClient signature (namespace-guard) — MagicMock hid the mismatch
+    """
+    # Mock DB with domain_categories table
+    db = MagicMock()
+    db.domain_categories.select = AsyncMock(return_value=[
+        MagicMock(categories=json.dumps(["malware", "phishing"])),
+        MagicMock(categories=json.dumps(["malware"])),
+    ])
+
+    # Use real CacheClient with unreachable port → in-memory fallback
+    cache = CacheClient(host="127.0.0.1", port=6399, db=0)
+
+    ingest = CategoryIngestManager(db, cache)
+
+    # Write cache for a domain
+    test_domain = "testdomain.com"
+    await ingest._write_cache(test_domain)
+
+    # Verify cache was written with correct signature
+    cached_value = await cache.get("sase:catcache", test_domain)
+    assert cached_value is not None
+
+    # Verify cached value contains the merged categories
+    categories = json.loads(cached_value)
+    assert "malware" in categories
+    assert "phishing" in categories

--- a/hub_api/tests/test_sase_swg_lookup.py
+++ b/hub_api/tests/test_sase_swg_lookup.py
@@ -1,12 +1,14 @@
 """Tests for SASE SWG domain lookup and enforcement action resolution."""
 from __future__ import annotations
 
+import json
 import pytest
 
 from hub_api.modules.sase.security.enforcement import EnforcementAction
 from hub_api.modules.sase.security.swg.lookup import SwgLookup
 from hub_api.modules.sase.security.swg.radix import RadixTree
 from hub_api.modules.sase.security.swg.policy import CategoryPolicyManager
+from hub_api.cache.client import CacheClient
 from unittest.mock import MagicMock, AsyncMock
 
 
@@ -91,3 +93,38 @@ def test_radix_to_lookup_flow() -> None:
 
     result = radix.lookup("a.shop.com")
     assert result == ("shopping",)
+
+
+@pytest.mark.asyncio
+async def test_lookup_catcache_hit_with_real_client() -> None:
+    """Test lookup cache hit using real CacheClient with fallback.
+
+    regression: swg catcache CacheClient signature (namespace-guard) — MagicMock hid the mismatch
+    """
+    radix = RadixTree()  # Empty radix, will fall through to cache
+
+    policy_mgr = MagicMock(spec=CategoryPolicyManager)
+    policy_mgr.resolve = AsyncMock(
+        return_value=(EnforcementAction.block, "tenant")
+    )
+
+    # Use real CacheClient with unreachable port → in-memory fallback
+    cache = CacheClient(host="127.0.0.1", port=6399, db=0)
+
+    # Pre-populate cache with categories
+    test_domain = "cached-example.com"
+    test_categories = ["malware", "phishing"]
+    cache_value = json.dumps(test_categories)
+    await cache.set("sase:catcache", test_domain, value=cache_value, ttl_seconds=3600)
+
+    lookup = SwgLookup(radix, policy_mgr, cache)
+
+    # Lookup should hit the cache
+    result = await lookup.lookup(test_domain, tenant="acme", user_id="user1")
+
+    # Verify cache hit returned the categories
+    assert result.domain == test_domain
+    assert set(result.categories) == set(test_categories)
+    assert result.action == EnforcementAction.block
+    assert result.matched_scope == "tenant"
+    assert not result.uncategorized


### PR DESCRIPTION
Latent bug in merged Slice B, surfaced during Slice E recon. `swg/lookup.py` + `ingest.py` passed the full pre-built key (`sase:catcache:<domain>`) as the CacheClient `namespace` arg (+ `ttl=` instead of `ttl_seconds=`), so the namespace guard raised `NamespaceError` — silently swallowed by fail-open/soft. The `sase:catcache:*` fast-index was **non-functional in production** (the radix silently carried every lookup). Tests passed only because they used `MagicMock()`.

- lookup.py: `cache.get("sase:catcache", domain, fail_closed=False)`; ingest.py: `cache.set("sase:catcache", domain, value=, ttl_seconds=86400)`.
- Tests now use a **real CacheClient** (in-memory fallback) so the signature is actually exercised — round-trip validated on both paths. `# regression: MagicMock hid the mismatch`.

Verified: canonical calls only; 8 tests pass; boot OK; collect 981/0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)