### PR TITLE
docs(sase): Slice C + E specs + plans (SASE Wave 2)

### DIFF
--- a/docs/superpowers/plans/2026-08-06-sase-slice-c-blockpages.md
+++ b/docs/superpowers/plans/2026-08-06-sase-slice-c-blockpages.md
@@ -1,0 +1,95 @@
+# SASE Slice C — Block Pages (Markdown) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: superpowers:subagent-driven-development. Steps use checkbox (`- [ ]`). Backend by `penguin-python-dev`; portal (Task 6) by `penguin-react-dev`.
+
+**Goal:** Markdown-based block/soft-block pages (drag-drop palette of basic md elements → markdown doc with template vars) + per-source block-routing + external-redirect (`X-Block-*`) + rule governance metadata; Python stores/serves definitions, data-plane renders (contract).
+
+**Architecture:** `blockpages/` module — `BlockPage` (markdown, draft/live+versions), `BlockRoute` (source_type→page|external), `RuleMetadata` governance; `render.py` markdown→sanitized HTML+vars; APIs derive tenant STRICTLY from claims; portal drag-drop markdown builder (dnd-kit).
+
+**Tech Stack:** Python 3.13, penguin-dal, Alembic, Quart, a markdown lib + HTML sanitizer; portal React 18 + Vite + TS + Tailwind v4 + dnd-kit.
+
+## Global Constraints
+
+- Spec: `docs/superpowers/specs/2026-08-06-sase-slice-c-blockpages-design.md` — authoritative.
+- Green gate: `python3 -m pytest hub_api/tests/` (baseline **979**, 0 fail) in batches; `create_app()` boots; `scripts/audit_imports.py --module sase --forbid sdwan,ziti` clean. Clean bytecode first.
+- **Commit-completeness (hard):** `git status --short` empty + `git show HEAD --stat` after each commit; `git check-ignore` new files; after push confirm origin SHA.
+- **TENANT FROM AUTHENTICATED CLAIMS ONLY** (Slice B shipped a cross-tenant bug — do NOT repeat): every API derives tenant from `current_claims()`/`g.tenant` via `@require_tenant`; a body/param/header tenant that mismatches → 403; every manager query filters by the authenticated tenant. A cross-tenant regression test per endpoint.
+- Render output is **sanitized** (strip script/style/event-handlers even from admin markdown). Missing route → global default page (fail-safe, never an error leaking internals).
+- Alembic: chain after head **0022** (→ 0023 block_pages, 0024 block_routes); declare in the sase `ModuleContract.migrations`. Flag `tobogganing.sase.blockpages` — community, `@require_feature("sase","blockpages")` (402 when off).
+- New deps (markdown lib + sanitizer + dnd-kit): pin exact + hashes; Socket-verify; Western/maintained only (no PRC).
+
+---
+
+## Task 1: Models + Alembic (block_pages, block_routes)
+
+**Files:** Create `hub_api/modules/sase/security/blockpages/__init__.py`, `models.py`, migrations `<0023>_block_pages.py`, `<0024>_block_routes.py`; Test `hub_api/tests/test_sase_blockpages_models.py`.
+
+**Interfaces:** `@dataclass(slots=True)` `BlockPage(id,tenant,name,markdown,status,version,created_by,updated_by,created_at,updated_at)`, `PageStatus(str,Enum){draft,live}`; `BlockRoute(id,tenant,source_type,destination_kind,page_id,external_url,created_at,+metadata)`, `RouteDest(str,Enum){page,external}`; `RuleMetadata(created_by,updated_by,ticket,notes,expiry,review_date,scope,risk)`.
+
+- [ ] Step 1: Read `sdwan/firewall/access_control.py` (dataclass+enum+Manager pattern) + `0002_sase_firewall_rules.py` (migration template; head is 0022). Step 2: Write failing test (construct the dataclasses + enums). Step 3: Implement models + the 2 migrations (block_pages: id,tenant idx,name,markdown,status,version,created_by,updated_by,timestamps; block_routes: id,tenant idx,source_type,destination_kind,page_id,external_url,+governance cols; down_revision chains 0022→0023→0024). Step 4: PASS. Step 5: Green gate (+migrations_head test) + commit.
+
+---
+
+## Task 2: `BlockPageManager` (CRUD + versioning, tenant-scoped)
+
+**Files:** Create `blockpages/pages.py`; Test `hub_api/tests/test_sase_blockpages_pages.py` (real-DAL).
+
+**Interfaces:** `BlockPageManager(db)`: `async create(tenant,name,markdown,created_by)`, `async update(tenant,page_id,markdown,updated_by)`, `async publish(tenant,page_id)` (draft→live, version++), `async revert(tenant,page_id,version)`, `async get_live(tenant,name)`, `async list_pages(tenant)`. Every method filters by `tenant`.
+
+- [ ] Step 1: Failing tests — create+get; publish bumps version + status=live; revert restores prior markdown; **cross-tenant: page under tenant A not visible/updatable by tenant B** (`# regression: cross-tenant`). Step 2: FAIL. Step 3: Implement (tenant-scoped queries). Step 4: PASS. Step 5: Green gate + commit.
+
+---
+
+## Task 3: `BlockRouteManager` + `resolve` + governance metadata
+
+**Files:** Create `blockpages/routes.py`; Test `hub_api/tests/test_sase_blockpages_routes.py`.
+
+**Interfaces:** `BlockRouteManager(db)`: `async set_route(tenant,source_type,destination_kind,page_id=None,external_url=None,metadata=None)`, `async get_routes(tenant)`, `async resolve(tenant,source_type) -> BlockRoute|None` (exact source_type → else global default → None).
+
+- [ ] Step 1: Failing tests — set+resolve picks the right route; missing source_type → default/None; governance metadata persisted+queryable; cross-tenant isolation. Step 2: FAIL. Step 3: Implement. Step 4: PASS. Step 5: Green gate + commit.
+
+---
+
+## Task 4: `render.py` (markdown → sanitized HTML + variables)
+
+**Files:** Create `blockpages/render.py` (+ pin markdown lib + sanitizer in requirements); Test `hub_api/tests/test_sase_blockpages_render.py`.
+
+**Interfaces:** `render_block_page(markdown: str, variables: dict[str,str]) -> str`; `VARIABLES` = the documented set.
+
+- [ ] Step 1: Add markdown lib (`markdown` or `mistune`) + sanitizer (`nh3`/`bleach`) to requirements.in, `uv pip compile --generate-hashes`. Step 2: Failing tests — markdown headings/img/text/link/list/divider render; `{{blocked_url}}` etc. substituted; a `<script>alert(1)</script>` in markdown is sanitized OUT of the HTML; unknown variable → empty/left-as-is (documented). Step 3: FAIL. Step 4: Implement (substitute vars → render markdown → sanitize HTML to a safe tag allowlist). Step 5: PASS. Step 6: Green gate + commit.
+
+---
+
+## Task 5: API + flag + contract registration
+
+**Files:** Create `blockpages/api.py`; Modify `hub_api/modules/sase/__init__.py` (flag `tobogganing.sase.blockpages`, `Entitlement(...,"community")`, blueprint, migrations 0023/0024); Test `hub_api/tests/test_sase_blockpages_api.py`.
+
+**Interfaces:** blueprint `sase_blockpages` `url_prefix="/blockpages"`: `GET|POST|PUT /pages`, `POST /pages/<id>/publish`, `POST /pages/<id>/preview`, `GET|PUT /routes`. Typed DTOs; `@require_tenant`+`@require_scope`+`@require_feature("sase","blockpages")`; **tenant from `current_claims()` only**.
+
+- [ ] Step 1: Failing tests — page CRUD+publish+preview (render) via API returns typed DTO; **body-tenant mismatch → 403** (`# regression: cross-tenant`); flag OFF → 402; write needs `sase:write`; external route response carries the documented `X-Block-*` header names. Step 2: FAIL. Step 3: Implement (mirror `blocklist/api.py` + the SWG cross-tenant-fixed pattern — tenant strictly from claims); register flag/entitlement/blueprint/migrations in `module()`. Step 4: PASS. Step 5: Green gate (+ `test_sase_module.py` + `test_registry.py`) + boot + commit.
+
+---
+
+## Task 6: Portal — markdown block-builder + routing-config UI (`penguin-react-dev`)
+
+**Files:** Create `portal/src/pages/sase/BlockPageBuilder.tsx`, `BlockRoutingConfig.tsx`; Modify `portal/src/api/sase.ts` (+client funcs), `portal/src/routes/saseViews.ts` (+slugs); Tests colocated `.test.tsx`.
+
+- [ ] Step 1: Add `dnd-kit` (exact pin) to `portal/package.json` + a markdown renderer for preview. Step 2: Build `BlockPageBuilder` — a drag-drop list of md-element blocks (h1–h4, image, text, link, list, divider); each block edits content; serialize ordered blocks → markdown; live preview; save/publish via `api/sase.ts`. Step 3: Build `BlockRoutingConfig` — source_type→destination table + governance fields. Step 4: Jest/RTL tests (builder serializes blocks → expected markdown; routing table CRUD; role-based visibility). Step 5: `npm run lint` + `npm test` pass; commit. (Screenshots per the marketing-screenshots rule since this is UI-affecting.)
+
+---
+
+## Task 7: Data-plane serving contract doc
+
+**Files:** Create `docs/architecture/sase-blockpage-serving-contract.md`.
+
+- [ ] Document: on `block`/`soft_block` (Slice B `EnforcementAction`), the Inspection Point resolves the `BlockRoute` for the block's `source_type` (pulled config, freshclam cadence — not per-request gRPC); `page` → fetch live markdown + render+sanitize+substitute vars → serve (403 block / interstitial soft_block); `external` → redirect with the `X-Block-*` header set; no route → global default. Commit.
+
+## Self-Review
+
+- **Spec coverage:** markdown page model→T1/T2/T4; versioning→T2; routing+resolve→T3; governance→T3; render+sanitize+vars→T4; API+flag+cross-tenant→T5; portal drag-drop builder→T6; external-redirect+X-Block-*→T5/T7; contract→T7. All covered.
+- **Placeholders:** none.
+- **Type consistency:** `BlockPage/BlockRoute/RuleMetadata`, `PageStatus/RouteDest`, `BlockPageManager.{create,update,publish,revert,get_live}`, `BlockRouteManager.{set_route,resolve}`, `render_block_page` — consistent.
+
+## Execution
+
+Backend T1-5,7 (`penguin-python-dev`), portal T6 (`penguin-react-dev`). Single feature branch `feature/sase-blockpages`. Parallel with Slice E (Wave 2); combine the sase-contract conflict at rebase (as B/D). Verify commit-completeness + clean-bytecode + full-suite + cross-tenant regressions before merge.

--- a/docs/superpowers/plans/2026-08-06-sase-slice-e-ai-categorizer.md
+++ b/docs/superpowers/plans/2026-08-06-sase-slice-e-ai-categorizer.md
@@ -1,0 +1,71 @@
+# SASE Slice E — OOB AI Tier-2 Categorizer Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: superpowers:subagent-driven-development. Steps use checkbox (`- [ ]`). Executed by `penguin-python-dev`.
+
+**Goal:** Categorize uncategorized domains out-of-band — sandboxed metadata scrape + non-generative sklearn classifier → write back to `domain_categories` (source="ai") + `sase:catcache:*`; replaces Slice B's `_enqueue_uncategorized` stub. Never blocks inline traffic.
+
+**Architecture:** `swg/tier2/` — SSRF-sandboxed `fetcher`, BeautifulSoup metadata `scraper`, TF-IDF+linear `classifier` (self-trained joblib, fail-safe), Celery `categorize_domain` task + write-back; hook wiring; professional flag. No new Alembic migration.
+
+**Tech Stack:** Python 3.13, httpx (pinned), beautifulsoup4, scikit-learn/numpy/scipy/joblib, celery, `CacheClient` (canonical signature), penguin-dal.
+
+## Global Constraints
+
+- Spec: `docs/superpowers/specs/2026-08-06-sase-slice-e-ai-categorizer-design.md` — authoritative.
+- Green gate: `python3 -m pytest hub_api/tests/` (baseline after catcache-fix + Wave-2 start; ~980+, 0 fail) in batches; `create_app()` boots; `scripts/audit_imports.py --module sase --forbid sdwan,ziti` clean. Clean bytecode first.
+- **Commit-completeness (hard):** `git status --short` empty + `git show HEAD --stat` after each commit; `git check-ignore` new files; after push confirm origin SHA.
+- **Out-of-band + fail-safe everywhere:** fetch fail/oversize/timeout → None; classifier no-model → `("uncategorized",0.0)`; Celery down → hook no-ops; NOTHING blocks the inline lookup or crashes.
+- **Prompt-injection defense (mandatory, tested):** non-generative classifier (fixed category set); metadata-only scrape (classifier never sees raw HTML/JS); SSRF-sandboxed fetcher (reject private/loopback/link-local/reserved IPs + redirects to them; size 512KB + time 5s caps; no cookies/creds/JS).
+- **Cache write uses the canonical signature:** `cache.set("sase:catcache", domain, value=json, ttl_seconds=86400)` — NEVER a pre-built full key (the bug the catcache-fix corrected).
+- **No new migration** — write-back reuses `domain_categories` (0021) with `source="ai"` via B's tenant-aware upsert.
+- New deps (`beautifulsoup4`, `scikit-learn`+`numpy`+`scipy`+`joblib`, `celery`) pinned + hashed via `uv pip compile --generate-hashes`; Socket-verified; Western/OSS, no PRC, no external model download.
+- Flag `tobogganing.sase.swg_ai_categorizer` — professional, `@require_feature` where surfaced; hook checks it before dispatch.
+
+---
+
+## Task 1: SSRF-sandboxed fetcher
+
+**Files:** Create `hub_api/modules/sase/security/swg/tier2/__init__.py`, `tier2/fetcher.py`; Test `hub_api/tests/test_sase_swg_tier2_fetcher.py`.
+
+**Interfaces:** `async fetch(url: str, *, max_bytes=512_000, timeout_s=5.0) -> bytes | None`; `is_public_host(host) -> bool` (resolves + rejects private/loopback/link-local/reserved/multicast).
+
+- [ ] Step 1: Failing tests (mock the transport / patch resolution): a URL resolving to `127.0.0.1`/`10.0.0.0`/`169.254.*`/`::1` → refused (None); a redirect to a private IP → refused; oversize body → truncated/None; timeout → None; a public host with a small body → bytes; no `Cookie`/`Authorization` header sent. `# regression: SSRF sandbox`. Step 2: FAIL. Step 3: Implement with `httpx` (async, `follow_redirects` handled manually so each hop's host is SSRF-checked; `ipaddress` to classify resolved IPs; size cap via streamed read; benign fixed UA; no cookies). Step 4: PASS. Step 5: Green gate + commit.
+
+---
+
+## Task 2: Metadata-only scraper
+
+**Files:** Create `tier2/scraper.py`; Test `hub_api/tests/test_sase_swg_tier2_scraper.py`.
+
+**Interfaces:** `extract_metadata(html: bytes, *, max_chars=4000) -> str` (title + meta description + h1–h3 + bounded visible text; strips script/style/hidden/event-handlers).
+
+- [ ] Step 1: Add `beautifulsoup4` (pin+hash). Step 2: Failing tests — extracts title/meta/h1–h3/text; a `<script>IGNORE PREVIOUS INSTRUCTIONS...</script>` and a `<style>` and `display:none` block → their text is ABSENT from the output; output ≤ max_chars; malformed HTML → best-effort, no raise. `# regression: injection stripped`. Step 3: FAIL. Step 4: Implement (BeautifulSoup, `.decompose()` script/style, skip hidden, join text, cap). Step 5: PASS. Step 6: Green gate + commit.
+
+---
+
+## Task 3: Non-generative classifier + train script
+
+**Files:** Create `tier2/classifier.py`, `tier2/train.py` (+ pin scikit-learn/numpy/scipy/joblib); Test `hub_api/tests/test_sase_swg_tier2_classifier.py`.
+
+**Interfaces:** `class DomainClassifier(model_path=None)`: `classify(text: str) -> tuple[str, float]`; `CONFIDENCE_THRESHOLD`; fail-safe `("uncategorized",0.0)` when the model is absent/unloadable. `train.py`: `build_model(samples, out_path)` (TF-IDF vectorizer + LinearSVC/LogisticRegression → joblib).
+
+- [ ] Step 1: Add sklearn stack (pin+hash). Step 2: Failing tests — train a tiny in-test model on ~6 labeled samples → `classify` returns a category in the trained set with a confidence; text below threshold → `uncategorized`; `DomainClassifier(model_path="/nonexistent")` → `("uncategorized",0.0)` no crash; output category is ALWAYS from the fixed set (non-generative). Step 3: FAIL. Step 4: Implement classifier (load joblib, TF-IDF transform, predict + decision-function/proba → confidence, threshold) + `train.py`. Step 5: PASS. Step 6: Green gate + commit.
+
+---
+
+## Task 4: Celery task + write-back + hook + flag + contract (+ fix dangling refresh handler)
+
+**Files:** Create `hub_api/modules/sase/security/swg/tasks.py`, `tier2/worker.py` (if separate); Modify `swg/lookup.py` (`_enqueue_uncategorized` → dispatch), `hub_api/modules/sase/__init__.py` (flag+entitlement+ register the task/handler); Test `hub_api/tests/test_sase_swg_tier2_worker.py`.
+
+**Interfaces:** Celery task `swg.categorize_domain(domain, tenant)` (sync task wrapping `asyncio.run(_categorize_async(...))`, model on `perftest_c2c/worker/tasks.py`): `fetch → extract_metadata → classify`; confident → upsert `domain_categories` (source="ai", tenant) + `cache.set("sase:catcache", domain, value=json.dumps(sorted([cat])), ttl_seconds=86400)`; else record uncategorized. Also `refresh_categories_daily(...)` implementing the handler B's `scheduler.py` registered (calls `CategoryIngestManager.ingest_all` + logs) — **fixes the dangling reference**. `_enqueue_uncategorized(domain, tenant)` → if flag on and Celery available: `categorize_domain.delay(domain, tenant)`; else log no-op.
+
+- [ ] Step 1: Add `celery` (pin+hash). Step 2: Failing tests — `categorize_domain` core on a confident fixture (mock fetch→html, real scraper+tiny classifier) writes `domain_categories`(source="ai") + catcache round-trips through a REAL CacheClient (in-memory fallback, canonical signature); low-confidence → no write; fetch-None → no write no raise; `_enqueue_uncategorized` dispatches when flag ON (mock `.delay`), no-op when OFF or Celery down; `refresh_categories_daily` runs ingest without error. Step 3: FAIL. Step 4: Implement tasks.py + hook rewiring + register flag `tobogganing.sase.swg_ai_categorizer`(professional)+entitlement in `module()`. Step 5: PASS. Step 6: Green gate (batch: new test + `test_sase_swg_lookup.py` + `test_sase_module.py` + `test_registry.py`) + boot + commit.
+
+## Self-Review
+
+- **Spec coverage:** SSRF fetcher→T1; metadata scraper→T2; classifier+train→T3; worker+write-back+hook+flag→T4; dangling `refresh_categories_daily` fix→T4; 3-layer injection defense→T1/T2/T3; no-migration write-back→T4; graceful degradation→T3/T4. All covered.
+- **Placeholders:** none — train.py is a real script; the shipped state (no model) fail-safes to uncategorized by design.
+- **Type consistency:** `fetch`/`is_public_host`, `extract_metadata`, `DomainClassifier.classify`, `categorize_domain`/`refresh_categories_daily`, canonical `cache.set` signature — consistent.
+
+## Execution
+
+Sequential (2→4 build up). Single feature branch `feature/sase-swg-ai` off release **after the catcache-fix lands**. Independent of Slice C (no shared migration) → parallel (Wave 2); combine the sase-contract conflict at rebase. Verify commit-completeness + clean-bytecode + full-suite + the SSRF/injection regressions before merge.

--- a/docs/superpowers/specs/2026-08-06-sase-slice-c-blockpages-design.md
+++ b/docs/superpowers/specs/2026-08-06-sase-slice-c-blockpages-design.md
@@ -1,0 +1,93 @@
+# SASE Slice C — Block Pages (Markdown) + Routing + Governance (Design Spec)
+
+**Date**: 2026-08-06
+**Status**: Design approved; ready for implementation plan
+**Cross-references**:
+- SASE security design: `docs/superpowers/specs/2026-07-26-sase-sdwan-ziti-core-split.md` ("Enforcement Actions & Block Handling")
+- Slice B enforcement enum (merged): `hub_api/modules/sase/security/enforcement.py` (`EnforcementAction`)
+- Reuse: `hub_api/modules/sdwan/firewall/access_control.py` (rule+DAL pattern), `hub_api/modules/sase/security/blocklist/api.py` (DTO + decorator convention), `hub_api/modules/sase/security/protection/middleware_core.py:97` (`X-Block-Reason`/`X-Security-Block` header precedent)
+
+## Goal
+
+When an `EnforcementAction` of `block`/`soft_block` fires, the Inspection Point serves a customer-branded page (or redirects to a customer server). Slice C provides: **markdown-based block/soft-block pages** with a drag-and-drop builder (basic markdown elements), **per-source block-routing config** (which page for which block reason), **external-redirect** with `X-Block-*` context headers, and **rule governance metadata**. Like A/B, Python stores + serves definitions; the data plane renders/serves at enforcement (contract).
+
+## Block-page model (locked — markdown, not a page-builder framework)
+
+A block page is a **markdown document** with template variables. The portal offers a **drag-and-drop palette of basic markdown elements** (h1–h4, image, paragraph/text, link/button, unordered/ordered list, divider); each dragged block edits its content; the builder serializes the ordered blocks to **markdown**. Stored as markdown (not HTML, not a JSON block tree). The data plane renders markdown → sanitized HTML at enforcement, substituting server-rendered variables: `{{blocked_url}}`, `{{category}}`, `{{reason}}`, `{{user}}`, `{{org}}`, `{{support_link}}`, `{{appeal_link}}`, `{{timestamp}}`.
+
+- Drag-and-drop is authoring UX only — the artifact is markdown; any editor that produces the same markdown is equivalent.
+- Per-tenant branding (logo image block, colors via a small front-matter block, messaging). Draft/live status + version history (revert).
+- Soft-block pages add a continuation control (`{{continue_url}}` / acknowledgement) rendered by the data plane.
+
+## Scope (locked)
+
+- **In**: backend block-page store (markdown + versioning), per-source block-routing config, rule governance metadata, external-redirect + `X-Block-*` header contract, typed APIs, a markdown render/preview function, the portal drag-and-drop markdown builder + route-config UI, data-plane serving contract doc.
+- **Out**: the data-plane rendering/serving itself (contract only — the Go/Rust Inspection Point renders); changing B's enforcement actions (C keys off them).
+
+## Components — backend `hub_api/modules/sase/security/blockpages/`
+
+- `models.py` — `@dataclass(slots=True)`:
+  - `BlockPage(id, tenant, name, markdown, status: PageStatus, version, created_by, updated_by, created_at, updated_at)`; `PageStatus ∈ {"draft","live"}`.
+  - `BlockRoute(id, tenant, source_type, destination_kind: RouteDest, page_id, external_url, created_at, ...governance)`; `RouteDest ∈ {"page","external"}`; `source_type` e.g. `web-category:gambling`, `oob-analysis:malware`, `custom-rule:<id>`, `soft-block`.
+  - `RuleMetadata(created_by, updated_by, ticket, notes, expiry, review_date, scope, risk)` embedded on `BlockRoute` (and reusable).
+- `pages.py` — `BlockPageManager(db)`: CRUD, `publish(page_id)` (draft→live + new version), `revert(page_id, version)`, `get_live(tenant, name)`. **Tenant-scoped from authenticated claims — NEVER from request body/params** (hard rule; Slice B's cross-tenant lesson: derive tenant from `g.tenant`/claims in the API layer, and every manager query filters by the authenticated tenant).
+- `routes.py` — `BlockRouteManager(db)`: routing-config CRUD; `resolve(tenant, source_type) -> BlockRoute|None` (which page/external for a block reason; fallback → global default).
+- `render.py` — `render_block_page(markdown, variables) -> str` (markdown → **sanitized** HTML with variable substitution; a safe subset — headings/img/text/link/list/divider; sanitize output even though admin-authored, defense-in-depth). Used for preview + as the reference the data-plane contract mirrors.
+- `api.py` — blueprint `url_prefix="/blockpages"`:
+  - Page CRUD `GET|POST|PUT /pages` + `POST /pages/<id>/publish` + `POST /pages/<id>/preview` (render with sample vars).
+  - Route-config `GET|PUT /routes`.
+  - All: `@require_tenant` + `@require_scope("sase:write"|"sase:read")` + `@require_feature("sase","blockpages")`; typed DTOs (exact fields, no raw model); **tenant strictly from `current_claims()`** — a body/param tenant that mismatches → 403.
+- Alembic: `block_pages`, `block_routes` (governance columns) tables — chain after head **0022** (so 0023, 0024); declared in the sase `ModuleContract.migrations`.
+
+## Components — portal `portal/src/pages/sase/` + `portal/src/api/`
+
+- A **BlockPageBuilder** page: drag-and-drop list of markdown-element blocks (dnd-kit — lightweight, MIT, React; pinned exact version) → serializes to markdown; live markdown preview; save/publish/version.
+- A **BlockRoutingConfig** page: the source_type → destination table (page or external URL) + governance-metadata fields.
+- `api/sase.ts` additions (typed client funcs), `routes/saseViews.ts` slugs, follow the existing portal conventions (recon-confirmed React 18 + Vite + TS + Tailwind v4).
+
+## External redirect + `X-Block-*` headers (contract)
+
+A `BlockRoute` with `destination_kind="external"` → the data plane redirects the blocked request to `external_url` with context headers (extends the existing `X-Block-Reason`/`X-Security-Block` precedent): `X-Blocked-URL`, `X-Block-Category`, `X-Block-Rule-ID`, `X-Block-Source`, `X-Block-User` (UUID), `X-Block-Tenant`, `X-Block-Reason`. The customer's server renders its own page (ZScaler/iBoss style).
+
+## Data-plane serving contract (doc, `docs/architecture/sase-blockpage-serving-contract.md`)
+
+On a `block`/`soft_block` action (from Slice B's `EnforcementAction`), the Inspection Point: resolves the `BlockRoute` for the block's `source_type` (via hub-api / a pulled config, freshclam cadence — not per-request gRPC); if `page` → fetches the live block-page markdown + renders markdown+variables → sanitized HTML + serves (403 for block, interstitial for soft_block); if `external` → redirects with `X-Block-*` headers; if no route → global default page. Pages/config pulled + cached like the radix (Slice B).
+
+## Flags & tier
+
+- Flag `tobogganing.sase.blockpages` — **community** (block handling is core SWG); default OFF. `Entitlement("sase.blockpages","community")` in the sase `module()`.
+
+## Dependencies
+
+- Markdown render: a maintained Western markdown lib (e.g. `markdown` or `mistune`) + an HTML sanitizer (e.g. `bleach` / `nh3`) — pin exact + hashes; Socket-verify. Portal: `dnd-kit` (MIT) + a markdown renderer for preview — pin exact.
+
+## Error handling
+
+- API derives tenant from claims only (cross-tenant is a hard 403 — the Slice-B lesson, baked in). Render sanitizes output (no script/style/event-handler injection even from admin markdown). Missing route → global default (fail-safe to a generic block page, never an error page that leaks internals). Preview/render never executes template variables as code (simple substitution only).
+
+## Testing
+
+- **Pages**: CRUD + publish (draft→live, version bumps) + revert; **cross-tenant**: a page created under tenant A is not readable/updatable by tenant B (regression, like B); tenant strictly from claims.
+- **Routes**: `resolve(source_type)` picks the right page/external; missing → default; governance metadata persisted + queryable.
+- **Render**: markdown → HTML with variables substituted; a `<script>` in the markdown is sanitized out; each md element type renders; soft-block continuation present.
+- **API**: typed DTO field sets; flag OFF → 402; write needs `sase:write`; body-tenant mismatch → 403; external route emits the documented `X-Block-*` header set (assert the header names/values on the redirect DTO/contract).
+- **Portal**: builder serializes blocks → expected markdown; preview renders; route-config table CRUD (Jest/RTL per the frontend standards).
+- Full-suite parity; boot clean; `audit_imports --module sase` clean.
+
+## Sequencing (for the plan)
+
+1. `models.py` + Alembic `block_pages`/`block_routes`.
+2. `pages.py` (`BlockPageManager`, versioning, tenant-scoped).
+3. `routes.py` (`BlockRouteManager`, `resolve`) + governance metadata.
+4. `render.py` (markdown→sanitized HTML + variables).
+5. `api.py` + flag + contract registration (tenant-from-claims baked in).
+6. Portal builder + routing-config UI (penguin-react-dev).
+7. Data-plane serving contract doc.
+
+Single feature branch `feature/sase-blockpages` off release. **Independent of Slice E** (`blockpages/` vs `swg` AI worker) → **parallel (Wave 2)**. Note: C and E both edit the sase `module()` contract → resolve that conflict at rebase (combine, as B/D did).
+
+## Notes
+
+- **Cross-tenant discipline baked in from the start** — Slice B shipped a cross-tenant bug the review caught; C's API derives tenant only from authenticated claims, with a regression test per endpoint.
+- C keys off Slice B's `EnforcementAction` (`block`/`soft_block` trigger a page; the enum is the seam).
+- Governance metadata model is reusable — later could extend to SWG policies + blocklist rules (out of scope here).

--- a/docs/superpowers/specs/2026-08-06-sase-slice-e-ai-categorizer-design.md
+++ b/docs/superpowers/specs/2026-08-06-sase-slice-e-ai-categorizer-design.md
@@ -1,0 +1,83 @@
+# SASE Slice E — OOB AI Tier-2 Categorizer (Design Spec)
+
+**Date**: 2026-08-06
+**Status**: Design approved; ready for implementation plan
+**Cross-references**:
+- SASE security design: `docs/superpowers/specs/2026-07-26-sase-sdwan-ziti-core-split.md` ("Tier 2: Out-of-Band Async AI")
+- Slice B SWG (merged): `hub_api/modules/sase/security/swg/` (`_enqueue_uncategorized` hook at `lookup.py:137`; `domain_categories` table migration 0021; `ingest.py` write-back patterns; the dangling `swg.tasks.refresh_categories_daily` handler in `scheduler.py`)
+- Shared cache: `CacheClient` (`sase:catcache:*`) — **use the canonical signature** `cache.set("sase:catcache", domain, value=, ttl_seconds=)` (see the SWG catcache signature fix)
+- Worker infra: `hub_api/scheduler/` + `hub_api/modules/perftest_c2c/worker/` (Celery over Valkey)
+
+## Goal
+
+Categorize **uncategorized** domains (from Slice B's enqueue hook) out-of-band: a Celery worker securely scrapes page **metadata** (prompt-injection-hardened), runs a **non-generative** classifier to assign a category, and writes back to `domain_categories` + `sase:catcache:*` so the next lookup is a local hit. Strictly out-of-band — never blocks the inline path; a categorization failure just leaves the domain at the tenant default.
+
+## Scope (locked)
+
+- **In**: replace B's `_enqueue_uncategorized` stub with a real Celery enqueue; a **sandboxed fetcher** (SSRF-guarded, no creds/JS, size+time caps); a **metadata-only scraper** (BeautifulSoup); a **non-generative classifier** (sklearn TF-IDF + linear); the categorize worker task + write-back; `swg/tasks.py` (also implementing the currently-dangling `refresh_categories_daily` the B scheduler registered); flag/tier.
+- **Out**: no new Alembic migration (reuse `domain_categories` 0021 for write-back — **avoids a migration-number collision with the parallel Slice C**); no LLM (the optional generative tier stays future); no change to B's radix/policy (E just adds rows the radix picks up on rebuild).
+
+## Decisions (locked)
+
+1. **Classifier = sklearn TF-IDF + linear model** (LogisticRegression/LinearSVC), not FastText/DistilBERT. Rationale (from recon + standards): non-generative (cannot be prompt-injected — the core defense), self-contained, BSD-3, cleanly hash-pinnable, a **self-trained joblib artifact we control** (no external model-weight download → clean provenance), deterministic, smallest footprint given the repo has zero ML today. FastText is the noted alternative if language-robustness is later needed; transformers/DistilBERT rejected (heavy, external weights, pin-unfriendly).
+2. **Worker = Celery over Valkey** (exists). The hook `.delay()`s a task; no polling.
+3. **No new migration** — write-back reuses `domain_categories` (source `"ai"`) + catcache.
+4. **Tier = professional** — new flag `tobogganing.sase.swg_ai_categorizer` (mirrors `context_auth`); base `sase.swg` stays community.
+
+## Prompt-injection defense (the explicit requirement — three layers)
+
+1. **Non-generative classifier** — outputs a category label from a fixed set, not free-form text; cannot be instruction-injected. Primary defense.
+2. **Metadata-only pre-parse** — BeautifulSoup extracts title, meta description, h1–h3, bounded visible-text snippet; strips `<script>`/`<style>`/event handlers/hidden text. The classifier NEVER sees raw HTML/JS.
+3. **Sandboxed fetcher** — SSRF-guarded (reject private/loopback/link-local/reserved IPs, re-check after each redirect — block redirects to internal targets), no cookies/creds, no JS (static fetch), size cap (512 KB) + time cap (5 s), fixed benign User-Agent.
+
+**Blast radius**: a successful trick yields a mis-category (a policy allow/block), not code exec or exfiltration; admin/custom category overrides (Slice B) correct it.
+
+## Components — `hub_api/modules/sase/security/swg/tier2/`
+
+- `fetcher.py` — `async fetch(url) -> bytes|None`: SSRF guard (resolve host → reject non-public IPs; block redirects to private), size+time caps, no creds/cookies/JS, benign UA; returns bounded bytes or None (fetch failure → None, fail-safe). Prefer `httpx` (already pinned) over unpinned aiohttp.
+- `scraper.py` — `extract_metadata(html: bytes) -> str`: BeautifulSoup → title + meta description + h1–h3 + bounded visible-text; strip script/style/hidden; return a size-capped text blob. Never returns raw HTML.
+- `classifier.py` — `class DomainClassifier`: `classify(text: str) -> tuple[str, float]` (category + confidence) from a loaded joblib TF-IDF+linear model; `MODEL_PATH` config; if the model artifact is absent/unloadable → return `("uncategorized", 0.0)` (fail-safe, never crashes). `CONFIDENCE_THRESHOLD` — below it → `uncategorized` (don't write a low-confidence guess).
+- `train.py` — offline training script: builds labeled samples (domains with known categories from `domain_categories` feeds → fetch metadata → label with their category), trains TF-IDF+linear, writes the joblib artifact. A `make`/script target; NOT run at request time. Ships a documented "train the model" step; until trained, the classifier fail-safes to uncategorized (E degrades gracefully — no worse than today).
+- `worker.py` / `swg/tasks.py` — Celery task `swg.categorize_domain(domain, tenant)`: `fetch → extract_metadata → classify`; if confident → write-back (`domain_categories` upsert `source="ai"` + `cache.set("sase:catcache", domain, value=, ttl_seconds=86400)`, canonical signature); else record uncategorized. Fail-soft (any error logged, task returns; never retried into a loop). Also implement `refresh_categories_daily` here (the handler B's `scheduler.py` already registered but which has no backing module — fixes that dangling reference; it calls B's `CategoryIngestManager.ingest_all` + triggers a radix rebuild).
+- Hook wiring — replace `SwgLookup._enqueue_uncategorized(domain, tenant)` (currently a no-op) with `swg.categorize_domain.delay(domain, tenant)` (guarded: if Celery unavailable, log + no-op — never break the inline lookup).
+
+## Flags & tier
+
+- Flag `tobogganing.sase.swg_ai_categorizer` — **professional**; default OFF. `Entitlement("sase.swg_ai_categorizer","professional")` in the sase `module()`. The enqueue hook checks the flag before dispatching (flag off → no-op, base SWG unaffected).
+
+## Dependencies (all Western/OSS, hash-pinned via `uv pip compile --generate-hashes`; Socket-verified)
+
+- `beautifulsoup4` (MIT) + `httpx` (already pinned) for scrape/fetch.
+- `scikit-learn` (BSD-3) + `numpy`/`scipy` (BSD) + `joblib` for the classifier.
+- `celery` (BSD) — currently a guarded/unpinned import; pin it.
+- No PRC-origin packages; no external model-weight download (model is self-trained + committed or built by the train step).
+
+## Error handling
+
+- Every stage fail-safe: fetch failure/timeout/oversize → None → task ends (domain stays uncategorized, tenant default applies). Classifier model absent → `uncategorized` (E is a no-op until a model is trained — graceful degradation, never a regression vs today). Enqueue when Celery is down → logged no-op (inline lookup never blocks). Cache write uses the canonical namespace-guarded signature; DB write reuses B's tenant-aware upsert.
+- SSRF guard is mandatory and tested — a fetch to a private/loopback/link-local target (or a redirect to one) must be refused.
+
+## Testing
+
+- **Fetcher**: rejects private/loopback/link-local/reserved IPs + redirects to them (SSRF); enforces size + time caps; no cookies sent; a normal public URL (mocked transport) returns bytes. (`# regression: SSRF sandbox`)
+- **Scraper**: extracts title/meta/h1–h3/text; strips `<script>`/`<style>`/hidden; a page with an injected instruction in a script tag → that text never appears in the extracted metadata; output size-capped.
+- **Classifier**: with a tiny fixture model → `classify` returns (category, confidence); below threshold → `uncategorized`; missing model → `("uncategorized",0.0)` no crash. Non-generative: output is always in the fixed category set.
+- **Worker**: `categorize_domain` on a confident fixture → writes `domain_categories` (source="ai") + catcache (canonical signature, round-trip via real CacheClient in-memory fallback); low-confidence → no write; fetch failure → no write, no raise. `refresh_categories_daily` invokes ingest without error.
+- **Hook**: `_enqueue_uncategorized` dispatches the task when flag ON; flag OFF → no dispatch; Celery-down → no-op, lookup still returns.
+- Full-suite parity; boot clean; `audit_imports --module sase` clean.
+
+## Sequencing (for the plan)
+
+1. `fetcher.py` (SSRF-sandboxed) — the security-critical piece; full tests.
+2. `scraper.py` (metadata-only, injection-stripping).
+3. `classifier.py` + `train.py` (TF-IDF+linear, fail-safe model load).
+4. `swg/tasks.py` (categorize_domain task + write-back + `refresh_categories_daily`) + hook wiring + flag + contract registration.
+5. Deps pinning (folded into the tasks that introduce each).
+
+Single feature branch `feature/sase-swg-ai` off release. **Independent of Slice C** (`swg/tier2/` vs `blockpages/`; E adds NO migration) → **parallel (Wave 2)**. Only shared file with C is the sase `module()` contract (both add a flag) → combine at rebase (as B/D).
+
+## Notes
+
+- E degrades gracefully: with the flag OFF or no trained model, behavior == today (uncategorized → tenant default). It only ever ADDS categorizations; it never blocks inline traffic (out-of-band mandate).
+- E depends on the SWG catcache signature fix (canonical `CacheClient` calls) — land that first so E's write-back actually populates the cache.
+- The self-trained model keeps provenance clean (no external weight download) and is the security-preferred choice over downloading third-party model binaries.


### PR DESCRIPTION
Specs + plans for the two SASE Wave-2 slices (build on merged A/B; disjoint modules → parallel).

- **Slice C** (`blockpages/`): markdown block/soft-block pages — drag-drop palette of basic md elements (h1-h4/img/text/link/list/divider) → markdown doc + template vars; per-source block-routing config; external-redirect `X-Block-*` headers; rule governance metadata; data-plane render contract. Cross-tenant-from-claims baked in (Slice B's lesson). 7 tasks.
- **Slice E** (`swg/tier2/`): out-of-band AI categorizer — SSRF-sandboxed fetch + BeautifulSoup metadata-only scrape + non-generative sklearn TF-IDF classifier → write back to `domain_categories`(source=ai)+catcache; replaces B's `_enqueue_uncategorized` stub; fixes B's dangling `refresh_categories_daily`; professional tier; NO new migration (parallel-safe with C). 4 tasks.

Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)