### PR TITLE
feat(k8s): Slice D optional off-by-default analysis-tool Helm sub-charts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -170,3 +170,8 @@ services/hub-router/proxy/headend-proxy
 
 # Git worktrees (local development only)
 .worktrees/
+
+# Helm: packaged local sub-chart archives are a `helm dependency
+# update`/`build` output regenerated from Chart.lock — the unpacked
+# k8s/helm/*/charts/<name>/ source directories themselves stay tracked.
+k8s/helm/*/charts/*.tgz

--- a/k8s/helm/tobogganing/Chart.lock
+++ b/k8s/helm/tobogganing/Chart.lock
@@ -1,0 +1,18 @@
+dependencies:
+- name: suricata
+  repository: file://./charts/suricata
+  version: 0.1.0
+- name: zeek
+  repository: file://./charts/zeek
+  version: 0.1.0
+- name: arkime
+  repository: file://./charts/arkime
+  version: 0.1.0
+- name: strelka
+  repository: file://./charts/strelka
+  version: 0.1.0
+- name: cape
+  repository: file://./charts/cape
+  version: 0.1.0
+digest: sha256:45644284ec5a84943042834dae5c37265d32a51b854e6e0decc53efd52d5ece7
+generated: "2026-08-06T21:47:26.76865112-05:00"

--- a/k8s/helm/tobogganing/Chart.yaml
+++ b/k8s/helm/tobogganing/Chart.yaml
@@ -4,3 +4,31 @@ description: Tobogganing - Zero Trust SASE Platform
 type: application
 version: 2.0.0
 appVersion: "2.0.0"
+
+## Optional, off-by-default out-of-band analysis-tool sub-charts (Slice D
+## adapters — see docs/superpowers/specs/2026-08-06-sase-slice-d-adapters-design.md
+## "Helm sub-charts"). Each condition maps to the matching top-level key in
+## values.yaml (e.g. suricata.enabled); all default false, so the baseline
+## product renders without any of them. See charts/README.md for the
+## mirror -> tool -> adapter -> blocklist flow and per-tool notes.
+dependencies:
+  - name: suricata
+    version: "0.1.0"
+    repository: "file://./charts/suricata"
+    condition: suricata.enabled
+  - name: zeek
+    version: "0.1.0"
+    repository: "file://./charts/zeek"
+    condition: zeek.enabled
+  - name: arkime
+    version: "0.1.0"
+    repository: "file://./charts/arkime"
+    condition: arkime.enabled
+  - name: strelka
+    version: "0.1.0"
+    repository: "file://./charts/strelka"
+    condition: strelka.enabled
+  - name: cape
+    version: "0.1.0"
+    repository: "file://./charts/cape"
+    condition: cape.enabled

--- a/k8s/helm/tobogganing/OPTIONAL_SUBCHARTS.md
+++ b/k8s/helm/tobogganing/OPTIONAL_SUBCHARTS.md
@@ -1,0 +1,88 @@
+# Optional Analysis-Tool Sub-Charts (SASE Slice D)
+
+Five out-of-band network/file analysis tools — **Suricata, Zeek, Arkime,
+Strelka, CAPE** — ship as optional Helm sub-charts under `charts/`. They
+are **off by default**: the baseline `tobogganing` chart deploys none of
+them, and enabling one only stands up its pod + Service. This is the
+first use of Helm's `dependencies:` + `condition:` mechanism in this
+chart (see `Chart.yaml`).
+
+> Not placed as `charts/README.md`: Helm's `dependency update`/`build`
+> treats every entry directly under `charts/` as a subchart candidate and
+> fails on anything without its own `Chart.yaml` (verified — a stray
+> `.md` file there breaks `helm dependency update` with `Chart.yaml file
+> is missing`). This note lives one level up instead.
+
+## Flow
+
+```
+hub-router (Go mirror)            5 sub-charts (charts/, off by default)
+  VXLAN/GRE/ERSPAN + direct   -->  Suricata / Zeek / Arkime / Strelka / CAPE
+  TCP feed to Suricata              |
+                                    v  writes EVE JSON / notice.log / API verdicts
+                                hub-api adapter poller
+                                (hub_api/modules/sase/security/adapters/)
+                                    |
+                                    v  normalize -> to_stix_indicator -> Verdict
+                                BlocklistStore (sase:blocklist:*)
+                                    |
+                                    v  (Slice A contract — data-plane read side,
+                                        out of scope for Slice D)
+                                enforcement
+```
+
+Everything left of `BlocklistStore` is **strictly out-of-band**: adapters
+read a mirror/log/API side-channel on a poll interval. Nothing in this
+directory touches the live traffic path.
+
+## Enabling a tool
+
+Enabling `<tool>.enabled: true` (top-level key in the parent chart's
+`values.yaml`) is necessary but not sufficient:
+
+1. Deploy the sub-chart: `<tool>.enabled: true`.
+2. Turn on the community-tier flag `tobogganing.sase.adapters` (default
+   OFF — registered in the `sase` module contract as
+   `Entitlement("sase.adapters", "community")`).
+3. Point hub-api's adapter poller at the tool via the
+   `{SOURCE}_ENABLED` / `{SOURCE}_ENDPOINT` / `{SOURCE}_LOG_PATH` env vars
+   read by `hub_api/modules/sase/security/adapters/config.py`
+   (`source` = `suricata|zeek|strelka|cape|arkime`), matching the
+   `mirror.port` / `eve.logPath` / `frontend.port` / etc. values
+   configured for that tool's sub-chart.
+
+## Per-tool notes
+
+| Tool | Image | Provenance | Port | Adapter wiring |
+|---|---|---|---|---|
+| Suricata | `jasonish/suricata:7.0.7` (SHA256-pinned) | Maintained by OISF core dev | 9999/TCP | Matches hub-router's existing `mirror.suricata_host`/`suricata_port` TCP feed — the one live wiring today |
+| Zeek | `zeek/zeek:6.2.1` (SHA256-pinned) | Official Zeek Project image | mgmt port reserved (placeholder) | Log-based (`notice.log`); no live mirror source yet |
+| Strelka | `target/strelka-frontend:1.0.1` (SHA256-pinned) | Target Corporation open source | 57314/TCP (gRPC) | Poller submits scans via gRPC |
+| Arkime | **none — operator-supplied** | No maintained public image found (checked Docker Hub `itsarkime`, `ghcr.io/arkime/arkime`) | 8005/TCP (viewer) | Set `arkime.image.*` before enabling; render fails otherwise |
+| CAPE | **none — operator-supplied** | Requires a hypervisor-backed sandbox host; not container-native | 8000/TCP (REST API) | Set `cape.image.*` before enabling; render fails otherwise |
+
+**Suricata runs with a documented root exception** (`NET_ADMIN`/`NET_RAW`
+for raw/AF_PACKET packet capture) mirroring the existing `hubRouter`
+exception already present in the parent chart's `values.yaml` — see
+`devops-containers.md` "Rootless Containers" exception process. All other
+four tools use the standard non-root securityContext.
+
+## Known integration gaps (by design — out of Slice D scope)
+
+- **Shared log volume**: Suricata's `eve.json` and Zeek's `notice.log`
+  are written to pod-local `emptyDir` volumes today. For hub-api's
+  poller to read `SURICATA_LOG_PATH`/`ZEEK_LOG_PATH` in production, an
+  operator needs to add a shared volume (e.g. an RWX PVC) mounted into
+  both the tool pod and hub-api — not provisioned by this chart. The
+  design doc calls this out explicitly as "a log volume with no consumer
+  today — that volume is the seam."
+- **NetworkPolicy**: the parent chart's default-deny + allow-internal
+  `NetworkPolicy` selects pods by the `tobogganing.*` label helpers.
+  These sub-charts use their own `app.kubernetes.io/name: <tool>` labels
+  and are not yet covered by an explicit allow rule. Add one scoped to
+  the tool's Service/port before relying on pod-to-pod traffic between
+  hub-api and an enabled tool.
+- **Zeek and Arkime are not wired to a live traffic mirror.** Only
+  Suricata has direct `hub-router` mirror wiring today
+  (`services/hub-router/proxy/mirror/manager.go`). Extending the Go
+  mirror to the other tools is out of scope for Slice D.

--- a/k8s/helm/tobogganing/charts/arkime/Chart.yaml
+++ b/k8s/helm/tobogganing/charts/arkime/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: arkime
+description: Optional out-of-band Arkime full-packet-capture/session viewer for Tobogganing SASE (Slice D adapter) — off by default
+type: application
+version: 0.1.0
+appVersion: "5.x"

--- a/k8s/helm/tobogganing/charts/arkime/templates/_helpers.tpl
+++ b/k8s/helm/tobogganing/charts/arkime/templates/_helpers.tpl
@@ -1,0 +1,21 @@
+{{/*
+Arkime sub-chart naming/label helpers. Self-contained — subcharts render
+independently of the parent chart's templates/_helpers.tpl.
+*/}}
+{{- define "arkime.fullname" -}}
+{{- printf "%s-arkime" .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{- define "arkime.labels" -}}
+app.kubernetes.io/name: arkime
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/part-of: tobogganing
+app.kubernetes.io/component: sase-adapter-tool
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+helm.sh/chart: {{ printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" }}
+{{- end }}
+
+{{- define "arkime.selectorLabels" -}}
+app.kubernetes.io/name: arkime
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}

--- a/k8s/helm/tobogganing/charts/arkime/templates/deployment.yaml
+++ b/k8s/helm/tobogganing/charts/arkime/templates/deployment.yaml
@@ -1,0 +1,74 @@
+{{- if .Values.enabled }}
+{{- if not .Values.image.repository }}
+{{- fail "arkime.enabled is true but arkime.image.repository is empty — no vetted default image ships with this stub; set image.repository/tag/digest to your own SHA256-pinned Arkime build first (see charts/arkime/values.yaml)." }}
+{{- end }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "arkime.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "arkime.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicas }}
+  selector:
+    matchLabels:
+      {{- include "arkime.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "arkime.selectorLabels" . | nindent 8 }}
+    spec:
+      securityContext:
+        runAsNonRoot: {{ .Values.securityContext.runAsNonRoot }}
+        runAsUser: {{ .Values.securityContext.runAsUser }}
+      containers:
+        - name: arkime
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}@{{ .Values.image.digest }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          securityContext:
+            allowPrivilegeEscalation: {{ .Values.securityContext.allowPrivilegeEscalation }}
+            readOnlyRootFilesystem: {{ .Values.securityContext.readOnlyRootFilesystem }}
+            capabilities:
+              drop:
+                {{- toYaml .Values.securityContext.capabilities.drop | nindent 16 }}
+          ports:
+            - name: viewer
+              containerPort: {{ .Values.viewer.port }}
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: {{ .Values.probes.liveness.httpGet.path }}
+              port: {{ .Values.probes.liveness.httpGet.port }}
+            initialDelaySeconds: {{ .Values.probes.liveness.initialDelaySeconds }}
+            periodSeconds: {{ .Values.probes.liveness.periodSeconds }}
+            timeoutSeconds: {{ .Values.probes.liveness.timeoutSeconds }}
+            failureThreshold: {{ .Values.probes.liveness.failureThreshold }}
+          readinessProbe:
+            httpGet:
+              path: {{ .Values.probes.readiness.httpGet.path }}
+              port: {{ .Values.probes.readiness.httpGet.port }}
+            initialDelaySeconds: {{ .Values.probes.readiness.initialDelaySeconds }}
+            periodSeconds: {{ .Values.probes.readiness.periodSeconds }}
+            timeoutSeconds: {{ .Values.probes.readiness.timeoutSeconds }}
+            failureThreshold: {{ .Values.probes.readiness.failureThreshold }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "arkime.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "arkime.labels" . | nindent 4 }}
+spec:
+  type: ClusterIP
+  ports:
+    - name: viewer
+      port: {{ .Values.viewer.port }}
+      targetPort: viewer
+      protocol: TCP
+  selector:
+    {{- include "arkime.selectorLabels" . | nindent 4 }}
+{{- end }}

--- a/k8s/helm/tobogganing/charts/arkime/values.yaml
+++ b/k8s/helm/tobogganing/charts/arkime/values.yaml
@@ -1,0 +1,62 @@
+## Arkime full-packet-capture/session viewer — out-of-band analysis tool
+## for SASE Slice D adapters. Deployed OFF by default (parent Chart.yaml:
+## condition arkime.enabled).
+##
+## No maintained public container image with verifiable provenance was
+## found for this tool at authoring time (checked Docker Hub org
+## `itsarkime` and ghcr.io/arkime/arkime — neither resolved). Per
+## PenguinTech supply-chain policy, this sub-chart ships as a stub with NO
+## default image rather than pinning an unverified third-party build.
+## Set image.repository/tag/digest to your own vetted, SHA256-pinned
+## Arkime build before setting enabled: true — the Deployment template
+## fails the render otherwise.
+enabled: false
+
+image:
+  repository: ""
+  tag: ""
+  digest: ""
+  pullPolicy: IfNotPresent
+
+replicas: 1
+
+## Arkime viewer's well-known default web UI port. The ArkimeAdapter
+## poller (hub_api/modules/sase/security/adapters/config.py:
+## ARKIME_ENDPOINT) reads session flags/tags from this endpoint.
+viewer:
+  port: 8005
+
+resources:
+  requests:
+    memory: "512Mi"
+    cpu: "500m"
+  limits:
+    memory: "1Gi"
+    cpu: "1000m"
+
+securityContext:
+  runAsNonRoot: true
+  runAsUser: 1000
+  allowPrivilegeEscalation: false
+  readOnlyRootFilesystem: true
+  capabilities:
+    drop:
+      - ALL
+
+probes:
+  liveness:
+    httpGet:
+      path: /
+      port: 8005
+    initialDelaySeconds: 20
+    periodSeconds: 30
+    timeoutSeconds: 5
+    failureThreshold: 3
+  readiness:
+    httpGet:
+      path: /
+      port: 8005
+    initialDelaySeconds: 10
+    periodSeconds: 15
+    timeoutSeconds: 3
+    failureThreshold: 3

--- a/k8s/helm/tobogganing/charts/cape/Chart.yaml
+++ b/k8s/helm/tobogganing/charts/cape/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: cape
+description: Optional out-of-band CAPE sandbox verdict API for Tobogganing SASE (Slice D adapter) — off by default
+type: application
+version: 0.1.0
+appVersion: "2.x"

--- a/k8s/helm/tobogganing/charts/cape/templates/_helpers.tpl
+++ b/k8s/helm/tobogganing/charts/cape/templates/_helpers.tpl
@@ -1,0 +1,21 @@
+{{/*
+CAPE sub-chart naming/label helpers. Self-contained — subcharts render
+independently of the parent chart's templates/_helpers.tpl.
+*/}}
+{{- define "cape.fullname" -}}
+{{- printf "%s-cape" .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{- define "cape.labels" -}}
+app.kubernetes.io/name: cape
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/part-of: tobogganing
+app.kubernetes.io/component: sase-adapter-tool
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+helm.sh/chart: {{ printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" }}
+{{- end }}
+
+{{- define "cape.selectorLabels" -}}
+app.kubernetes.io/name: cape
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}

--- a/k8s/helm/tobogganing/charts/cape/templates/deployment.yaml
+++ b/k8s/helm/tobogganing/charts/cape/templates/deployment.yaml
@@ -1,0 +1,74 @@
+{{- if .Values.enabled }}
+{{- if not .Values.image.repository }}
+{{- fail "cape.enabled is true but cape.image.repository is empty — no vetted default image ships with this stub; set image.repository/tag/digest to your own SHA256-pinned CAPE REST-API build first (see charts/cape/values.yaml)." }}
+{{- end }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "cape.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "cape.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicas }}
+  selector:
+    matchLabels:
+      {{- include "cape.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "cape.selectorLabels" . | nindent 8 }}
+    spec:
+      securityContext:
+        runAsNonRoot: {{ .Values.securityContext.runAsNonRoot }}
+        runAsUser: {{ .Values.securityContext.runAsUser }}
+      containers:
+        - name: cape
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}@{{ .Values.image.digest }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          securityContext:
+            allowPrivilegeEscalation: {{ .Values.securityContext.allowPrivilegeEscalation }}
+            readOnlyRootFilesystem: {{ .Values.securityContext.readOnlyRootFilesystem }}
+            capabilities:
+              drop:
+                {{- toYaml .Values.securityContext.capabilities.drop | nindent 16 }}
+          ports:
+            - name: api
+              containerPort: {{ .Values.api.port }}
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: {{ .Values.probes.liveness.httpGet.path }}
+              port: {{ .Values.probes.liveness.httpGet.port }}
+            initialDelaySeconds: {{ .Values.probes.liveness.initialDelaySeconds }}
+            periodSeconds: {{ .Values.probes.liveness.periodSeconds }}
+            timeoutSeconds: {{ .Values.probes.liveness.timeoutSeconds }}
+            failureThreshold: {{ .Values.probes.liveness.failureThreshold }}
+          readinessProbe:
+            httpGet:
+              path: {{ .Values.probes.readiness.httpGet.path }}
+              port: {{ .Values.probes.readiness.httpGet.port }}
+            initialDelaySeconds: {{ .Values.probes.readiness.initialDelaySeconds }}
+            periodSeconds: {{ .Values.probes.readiness.periodSeconds }}
+            timeoutSeconds: {{ .Values.probes.readiness.timeoutSeconds }}
+            failureThreshold: {{ .Values.probes.readiness.failureThreshold }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "cape.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "cape.labels" . | nindent 4 }}
+spec:
+  type: ClusterIP
+  ports:
+    - name: api
+      port: {{ .Values.api.port }}
+      targetPort: api
+      protocol: TCP
+  selector:
+    {{- include "cape.selectorLabels" . | nindent 4 }}
+{{- end }}

--- a/k8s/helm/tobogganing/charts/cape/values.yaml
+++ b/k8s/helm/tobogganing/charts/cape/values.yaml
@@ -1,0 +1,62 @@
+## CAPE sandbox verdict API — out-of-band analysis tool for SASE Slice D
+## adapters. Deployed OFF by default (parent Chart.yaml: condition
+## cape.enabled).
+##
+## No safe generic container image exists upstream: CAPE's architecture
+## requires a hypervisor (VirtualBox/KVM) to detonate samples in guest
+## VMs, which a single stub pod cannot provide and which is out of scope
+## for this chart. This sub-chart ships with NO default image — it only
+## deploys the REST API front-end container once you supply one backed by
+## your own sandbox-host infrastructure. Set image.repository/tag/digest
+## before setting enabled: true — the Deployment template fails the
+## render otherwise.
+enabled: false
+
+image:
+  repository: ""
+  tag: ""
+  digest: ""
+  pullPolicy: IfNotPresent
+
+replicas: 1
+
+## CAPE's REST API default port (inherited from the Cuckoo lineage). The
+## CapeAdapter poller (hub_api/modules/sase/security/adapters/config.py:
+## CAPE_ENDPOINT) reads verdicts from this endpoint.
+api:
+  port: 8000
+
+resources:
+  requests:
+    memory: "512Mi"
+    cpu: "500m"
+  limits:
+    memory: "1Gi"
+    cpu: "1000m"
+
+securityContext:
+  runAsNonRoot: true
+  runAsUser: 1000
+  allowPrivilegeEscalation: false
+  readOnlyRootFilesystem: true
+  capabilities:
+    drop:
+      - ALL
+
+probes:
+  liveness:
+    httpGet:
+      path: /
+      port: 8000
+    initialDelaySeconds: 20
+    periodSeconds: 30
+    timeoutSeconds: 5
+    failureThreshold: 3
+  readiness:
+    httpGet:
+      path: /
+      port: 8000
+    initialDelaySeconds: 10
+    periodSeconds: 15
+    timeoutSeconds: 3
+    failureThreshold: 3

--- a/k8s/helm/tobogganing/charts/strelka/Chart.yaml
+++ b/k8s/helm/tobogganing/charts/strelka/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: strelka
+description: Optional out-of-band Strelka file-scanning/YARA pipeline for Tobogganing SASE (Slice D adapter) — off by default
+type: application
+version: 0.1.0
+appVersion: "1.0.1"

--- a/k8s/helm/tobogganing/charts/strelka/templates/_helpers.tpl
+++ b/k8s/helm/tobogganing/charts/strelka/templates/_helpers.tpl
@@ -1,0 +1,21 @@
+{{/*
+Strelka sub-chart naming/label helpers. Self-contained — subcharts render
+independently of the parent chart's templates/_helpers.tpl.
+*/}}
+{{- define "strelka.fullname" -}}
+{{- printf "%s-strelka" .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{- define "strelka.labels" -}}
+app.kubernetes.io/name: strelka
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/part-of: tobogganing
+app.kubernetes.io/component: sase-adapter-tool
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+helm.sh/chart: {{ printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" }}
+{{- end }}
+
+{{- define "strelka.selectorLabels" -}}
+app.kubernetes.io/name: strelka
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}

--- a/k8s/helm/tobogganing/charts/strelka/templates/deployment.yaml
+++ b/k8s/helm/tobogganing/charts/strelka/templates/deployment.yaml
@@ -1,0 +1,69 @@
+{{- if .Values.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "strelka.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "strelka.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicas }}
+  selector:
+    matchLabels:
+      {{- include "strelka.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "strelka.selectorLabels" . | nindent 8 }}
+    spec:
+      securityContext:
+        runAsNonRoot: {{ .Values.securityContext.runAsNonRoot }}
+        runAsUser: {{ .Values.securityContext.runAsUser }}
+      containers:
+        - name: strelka-frontend
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}@{{ .Values.image.digest }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          securityContext:
+            allowPrivilegeEscalation: {{ .Values.securityContext.allowPrivilegeEscalation }}
+            readOnlyRootFilesystem: {{ .Values.securityContext.readOnlyRootFilesystem }}
+            capabilities:
+              drop:
+                {{- toYaml .Values.securityContext.capabilities.drop | nindent 16 }}
+          ports:
+            - name: grpc
+              containerPort: {{ .Values.frontend.port }}
+              protocol: TCP
+          livenessProbe:
+            tcpSocket:
+              port: {{ .Values.probes.liveness.tcpSocket.port }}
+            initialDelaySeconds: {{ .Values.probes.liveness.initialDelaySeconds }}
+            periodSeconds: {{ .Values.probes.liveness.periodSeconds }}
+            timeoutSeconds: {{ .Values.probes.liveness.timeoutSeconds }}
+            failureThreshold: {{ .Values.probes.liveness.failureThreshold }}
+          readinessProbe:
+            tcpSocket:
+              port: {{ .Values.probes.readiness.tcpSocket.port }}
+            initialDelaySeconds: {{ .Values.probes.readiness.initialDelaySeconds }}
+            periodSeconds: {{ .Values.probes.readiness.periodSeconds }}
+            timeoutSeconds: {{ .Values.probes.readiness.timeoutSeconds }}
+            failureThreshold: {{ .Values.probes.readiness.failureThreshold }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "strelka.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "strelka.labels" . | nindent 4 }}
+spec:
+  type: ClusterIP
+  ports:
+    - name: grpc
+      port: {{ .Values.frontend.port }}
+      targetPort: grpc
+      protocol: TCP
+  selector:
+    {{- include "strelka.selectorLabels" . | nindent 4 }}
+{{- end }}

--- a/k8s/helm/tobogganing/charts/strelka/values.yaml
+++ b/k8s/helm/tobogganing/charts/strelka/values.yaml
@@ -1,0 +1,53 @@
+## Strelka file-scanning/YARA pipeline (Target's open-source strelka-
+## frontend — the gRPC-facing component a scan-submitting client talks
+## to) — out-of-band analysis tool for SASE Slice D adapters. Deployed
+## OFF by default (parent Chart.yaml: condition strelka.enabled).
+enabled: false
+
+image:
+  repository: target/strelka-frontend
+  tag: "1.0.1"
+  digest: "sha256:5a713323733240c2028a49e01a008d35aeb955239b75e11d8cb86300369ab524"
+  pullPolicy: IfNotPresent
+
+replicas: 1
+
+## gRPC port the StrelkaAdapter poller submits scans to
+## (hub_api/modules/sase/security/adapters/config.py: STRELKA_ENDPOINT).
+## 57314 matches Strelka's published docker-compose.yml frontend port —
+## confirm against your Strelka deployment before relying on it in prod.
+frontend:
+  port: 57314
+
+resources:
+  requests:
+    memory: "512Mi"
+    cpu: "500m"
+  limits:
+    memory: "1Gi"
+    cpu: "1000m"
+
+securityContext:
+  runAsNonRoot: true
+  runAsUser: 1000
+  allowPrivilegeEscalation: false
+  readOnlyRootFilesystem: true
+  capabilities:
+    drop:
+      - ALL
+
+probes:
+  liveness:
+    tcpSocket:
+      port: 57314
+    initialDelaySeconds: 20
+    periodSeconds: 30
+    timeoutSeconds: 5
+    failureThreshold: 3
+  readiness:
+    tcpSocket:
+      port: 57314
+    initialDelaySeconds: 10
+    periodSeconds: 15
+    timeoutSeconds: 3
+    failureThreshold: 3

--- a/k8s/helm/tobogganing/charts/suricata/Chart.yaml
+++ b/k8s/helm/tobogganing/charts/suricata/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: suricata
+description: Optional out-of-band Suricata IDS analysis tool for Tobogganing SASE (Slice D adapter) — off by default
+type: application
+version: 0.1.0
+appVersion: "7.0.7"

--- a/k8s/helm/tobogganing/charts/suricata/templates/_helpers.tpl
+++ b/k8s/helm/tobogganing/charts/suricata/templates/_helpers.tpl
@@ -1,0 +1,21 @@
+{{/*
+Suricata sub-chart naming/label helpers. Self-contained — subcharts render
+independently of the parent chart's templates/_helpers.tpl.
+*/}}
+{{- define "suricata.fullname" -}}
+{{- printf "%s-suricata" .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{- define "suricata.labels" -}}
+app.kubernetes.io/name: suricata
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/part-of: tobogganing
+app.kubernetes.io/component: sase-adapter-tool
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+helm.sh/chart: {{ printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" }}
+{{- end }}
+
+{{- define "suricata.selectorLabels" -}}
+app.kubernetes.io/name: suricata
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}

--- a/k8s/helm/tobogganing/charts/suricata/templates/deployment.yaml
+++ b/k8s/helm/tobogganing/charts/suricata/templates/deployment.yaml
@@ -1,0 +1,78 @@
+{{- if .Values.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "suricata.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "suricata.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicas }}
+  selector:
+    matchLabels:
+      {{- include "suricata.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "suricata.selectorLabels" . | nindent 8 }}
+    spec:
+      securityContext:
+        runAsNonRoot: {{ .Values.securityContext.runAsNonRoot }}
+        runAsUser: {{ .Values.securityContext.runAsUser }}
+      containers:
+        - name: suricata
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}@{{ .Values.image.digest }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ## ROOT EXCEPTION (approved): requires NET_ADMIN/NET_RAW for raw
+          ## packet capture off mirrored traffic — see values.yaml.
+          securityContext:
+            allowPrivilegeEscalation: {{ .Values.securityContext.allowPrivilegeEscalation }}
+            capabilities:
+              add:
+                {{- toYaml .Values.securityContext.capabilities.add | nindent 16 }}
+          ports:
+            - name: mirror-feed
+              containerPort: {{ .Values.mirror.port }}
+              protocol: TCP
+          livenessProbe:
+            exec:
+              command:
+                {{- toYaml .Values.probes.liveness.command | nindent 16 }}
+            initialDelaySeconds: {{ .Values.probes.liveness.initialDelaySeconds }}
+            periodSeconds: {{ .Values.probes.liveness.periodSeconds }}
+            timeoutSeconds: {{ .Values.probes.liveness.timeoutSeconds }}
+            failureThreshold: {{ .Values.probes.liveness.failureThreshold }}
+          readinessProbe:
+            exec:
+              command:
+                {{- toYaml .Values.probes.readiness.command | nindent 16 }}
+            initialDelaySeconds: {{ .Values.probes.readiness.initialDelaySeconds }}
+            periodSeconds: {{ .Values.probes.readiness.periodSeconds }}
+            timeoutSeconds: {{ .Values.probes.readiness.timeoutSeconds }}
+            failureThreshold: {{ .Values.probes.readiness.failureThreshold }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          volumeMounts:
+            - name: eve-log
+              mountPath: /var/log/suricata
+      volumes:
+        - name: eve-log
+          emptyDir: {}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "suricata.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "suricata.labels" . | nindent 4 }}
+spec:
+  type: ClusterIP
+  ports:
+    - name: mirror-feed
+      port: {{ .Values.mirror.port }}
+      targetPort: mirror-feed
+      protocol: TCP
+  selector:
+    {{- include "suricata.selectorLabels" . | nindent 4 }}
+{{- end }}

--- a/k8s/helm/tobogganing/charts/suricata/values.yaml
+++ b/k8s/helm/tobogganing/charts/suricata/values.yaml
@@ -1,0 +1,64 @@
+## Suricata IDS/IPS — out-of-band analysis tool for SASE Slice D adapters.
+## Deployed OFF by default (parent Chart.yaml: condition suricata.enabled).
+## These are standalone-render defaults; when installed as part of the
+## umbrella tobogganing chart, the parent values.yaml `suricata:` block
+## overrides them (standard Helm subchart value passing).
+enabled: false
+
+image:
+  repository: jasonish/suricata
+  tag: "7.0.7"
+  digest: "sha256:b76d6bc42a572757d01b9289f1da250c6414ae69183505f694f75cd14025129f"
+  pullPolicy: IfNotPresent
+
+replicas: 1
+
+## TCP port hub-router's mirror manager dials (mirror.suricata_host /
+## mirror.suricata_port in services/hub-router/proxy/bootstrap.go,
+## default 9999) to push mirrored packet copies out-of-band.
+mirror:
+  port: 9999
+
+## Path the SuricataAdapter poller tails for EVE JSON
+## (hub_api/modules/sase/security/adapters/config.py: SURICATA_LOG_PATH).
+## Pod-local emptyDir by default — reading it from hub-api requires a
+## shared volume (e.g. an RWX PVC) mounted into both pods, which this
+## chart does not provision. See ../README.md.
+eve:
+  logPath: /var/log/suricata/eve.json
+
+resources:
+  requests:
+    memory: "512Mi"
+    cpu: "500m"
+  limits:
+    memory: "1Gi"
+    cpu: "1000m"
+
+securityContext:
+  ## ROOT EXCEPTION (approved): Suricata needs NET_ADMIN + NET_RAW to open
+  ## raw/AF_PACKET sockets for packet capture off mirrored traffic.
+  ## Mirrors the existing hubRouter exception in the parent chart's
+  ## values.yaml — see devops-containers.md "Rootless Containers"
+  ## exception process.
+  runAsNonRoot: false
+  runAsUser: 0
+  allowPrivilegeEscalation: true
+  capabilities:
+    add:
+      - NET_ADMIN
+      - NET_RAW
+
+probes:
+  liveness:
+    command: ["sh", "-c", "pgrep -x suricata"]
+    initialDelaySeconds: 20
+    periodSeconds: 30
+    timeoutSeconds: 5
+    failureThreshold: 3
+  readiness:
+    command: ["sh", "-c", "pgrep -x suricata"]
+    initialDelaySeconds: 10
+    periodSeconds: 15
+    timeoutSeconds: 3
+    failureThreshold: 3

--- a/k8s/helm/tobogganing/charts/zeek/Chart.yaml
+++ b/k8s/helm/tobogganing/charts/zeek/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: zeek
+description: Optional out-of-band Zeek network security monitor for Tobogganing SASE (Slice D adapter) — off by default
+type: application
+version: 0.1.0
+appVersion: "6.2.1"

--- a/k8s/helm/tobogganing/charts/zeek/templates/_helpers.tpl
+++ b/k8s/helm/tobogganing/charts/zeek/templates/_helpers.tpl
@@ -1,0 +1,21 @@
+{{/*
+Zeek sub-chart naming/label helpers. Self-contained — subcharts render
+independently of the parent chart's templates/_helpers.tpl.
+*/}}
+{{- define "zeek.fullname" -}}
+{{- printf "%s-zeek" .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{- define "zeek.labels" -}}
+app.kubernetes.io/name: zeek
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/part-of: tobogganing
+app.kubernetes.io/component: sase-adapter-tool
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+helm.sh/chart: {{ printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" }}
+{{- end }}
+
+{{- define "zeek.selectorLabels" -}}
+app.kubernetes.io/name: zeek
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}

--- a/k8s/helm/tobogganing/charts/zeek/templates/deployment.yaml
+++ b/k8s/helm/tobogganing/charts/zeek/templates/deployment.yaml
@@ -1,0 +1,77 @@
+{{- if .Values.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "zeek.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "zeek.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicas }}
+  selector:
+    matchLabels:
+      {{- include "zeek.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "zeek.selectorLabels" . | nindent 8 }}
+    spec:
+      securityContext:
+        runAsNonRoot: {{ .Values.securityContext.runAsNonRoot }}
+        runAsUser: {{ .Values.securityContext.runAsUser }}
+      containers:
+        - name: zeek
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}@{{ .Values.image.digest }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          securityContext:
+            allowPrivilegeEscalation: {{ .Values.securityContext.allowPrivilegeEscalation }}
+            readOnlyRootFilesystem: {{ .Values.securityContext.readOnlyRootFilesystem }}
+            capabilities:
+              drop:
+                {{- toYaml .Values.securityContext.capabilities.drop | nindent 16 }}
+          ports:
+            - name: zeek-mgmt
+              containerPort: {{ .Values.mgmt.port }}
+              protocol: TCP
+          livenessProbe:
+            exec:
+              command:
+                {{- toYaml .Values.probes.liveness.command | nindent 16 }}
+            initialDelaySeconds: {{ .Values.probes.liveness.initialDelaySeconds }}
+            periodSeconds: {{ .Values.probes.liveness.periodSeconds }}
+            timeoutSeconds: {{ .Values.probes.liveness.timeoutSeconds }}
+            failureThreshold: {{ .Values.probes.liveness.failureThreshold }}
+          readinessProbe:
+            exec:
+              command:
+                {{- toYaml .Values.probes.readiness.command | nindent 16 }}
+            initialDelaySeconds: {{ .Values.probes.readiness.initialDelaySeconds }}
+            periodSeconds: {{ .Values.probes.readiness.periodSeconds }}
+            timeoutSeconds: {{ .Values.probes.readiness.timeoutSeconds }}
+            failureThreshold: {{ .Values.probes.readiness.failureThreshold }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          volumeMounts:
+            - name: zeek-logs
+              mountPath: /usr/local/zeek/logs
+      volumes:
+        - name: zeek-logs
+          emptyDir: {}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "zeek.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "zeek.labels" . | nindent 4 }}
+spec:
+  type: ClusterIP
+  ports:
+    - name: zeek-mgmt
+      port: {{ .Values.mgmt.port }}
+      targetPort: zeek-mgmt
+      protocol: TCP
+  selector:
+    {{- include "zeek.selectorLabels" . | nindent 4 }}
+{{- end }}

--- a/k8s/helm/tobogganing/charts/zeek/values.yaml
+++ b/k8s/helm/tobogganing/charts/zeek/values.yaml
@@ -1,0 +1,60 @@
+## Zeek network security monitor — out-of-band analysis tool for SASE
+## Slice D adapters. Deployed OFF by default (parent Chart.yaml: condition
+## zeek.enabled). Not yet wired to a live mirror in this slice — only
+## Suricata has direct hub-router mirror wiring today (see
+## services/hub-router/proxy/mirror/manager.go); this stub establishes the
+## deployable pattern for when Zeek gets a traffic source.
+enabled: false
+
+image:
+  repository: zeek/zeek
+  tag: "6.2.1"
+  digest: "sha256:825d7f338cb539fa0e937cab5a68a4859e696cdc851dc06428a3961e6bb16014"
+  pullPolicy: IfNotPresent
+
+replicas: 1
+
+## Path the ZeekAdapter poller tails for notice.log
+## (hub_api/modules/sase/security/adapters/config.py: ZEEK_LOG_PATH).
+## Pod-local emptyDir by default — see ../README.md for the shared-volume
+## wiring needed to make this readable from hub-api.
+notice:
+  logPath: /usr/local/zeek/logs/current/notice.log
+
+## Reserved for future direct integration (e.g. a management/metrics
+## endpoint) — Zeek is log-based in this deployment, not endpoint-polled,
+## so nothing listens here yet. Kept for Service/values symmetry with the
+## other four tools.
+mgmt:
+  port: 9997
+
+resources:
+  requests:
+    memory: "512Mi"
+    cpu: "500m"
+  limits:
+    memory: "1Gi"
+    cpu: "1000m"
+
+securityContext:
+  runAsNonRoot: true
+  runAsUser: 1000
+  allowPrivilegeEscalation: false
+  readOnlyRootFilesystem: true
+  capabilities:
+    drop:
+      - ALL
+
+probes:
+  liveness:
+    command: ["sh", "-c", "pgrep -x zeek"]
+    initialDelaySeconds: 20
+    periodSeconds: 30
+    timeoutSeconds: 5
+    failureThreshold: 3
+  readiness:
+    command: ["sh", "-c", "pgrep -x zeek"]
+    initialDelaySeconds: 10
+    periodSeconds: 15
+    timeoutSeconds: 3
+    failureThreshold: 3

--- a/k8s/helm/tobogganing/values.yaml
+++ b/k8s/helm/tobogganing/values.yaml
@@ -209,3 +209,132 @@ config:
   hubRouterMetricsUrl: "http://hub-router:9090"
   redisUrl: "redis://redis:6379"
   dbType: "sqlite"
+
+## ---------------------------------------------------------------------
+## Optional out-of-band analysis tools (SASE Slice D adapters)
+## ---------------------------------------------------------------------
+## Suricata, Zeek, Arkime, Strelka, and CAPE ship as OFF-BY-DEFAULT Helm
+## sub-charts (see Chart.yaml `dependencies:` + `charts/<tool>/`). The
+## baseline product deploys without any of them.
+##
+## Enabling a tool here (`<tool>.enabled: true`) only deploys its pod +
+## Service. To actually turn on detection you must ALSO:
+##   1. Enable the community-tier flag `tobogganing.sase.adapters`
+##      (hub_api sase module contract — Entitlement("sase.adapters",
+##      "community"), default OFF).
+##   2. Configure hub-api's adapter poller to reach the tool via the
+##      {SOURCE}_ENABLED / {SOURCE}_ENDPOINT / {SOURCE}_LOG_PATH env vars
+##      read by hub_api/modules/sase/security/adapters/config.py
+##      (source = suricata|zeek|strelka|cape|arkime), pointed at the
+##      endpoint/logPath values configured below for each tool.
+## See k8s/helm/tobogganing/charts/README.md for the full
+## mirror -> tool -> adapter -> blocklist flow and known integration gaps.
+
+## Suricata IDS — the one tool hub-router's Go mirror already wires a raw
+## TCP feed to (mirror.suricata_host/mirror.suricata_port, default port
+## 9999 — services/hub-router/proxy/bootstrap.go).
+suricata:
+  enabled: false
+  image:
+    repository: jasonish/suricata
+    tag: "7.0.7"
+    digest: "sha256:b76d6bc42a572757d01b9289f1da250c6414ae69183505f694f75cd14025129f"
+    pullPolicy: IfNotPresent
+  replicas: 1
+  mirror:
+    port: 9999
+  eve:
+    logPath: /var/log/suricata/eve.json
+  resources:
+    requests:
+      memory: "512Mi"
+      cpu: "500m"
+    limits:
+      memory: "1Gi"
+      cpu: "1000m"
+
+## Zeek network security monitor — log-based in this deployment (no live
+## mirror wiring yet; only Suricata has that today). Establishes the
+## deployable pattern for when a traffic source is added.
+zeek:
+  enabled: false
+  image:
+    repository: zeek/zeek
+    tag: "6.2.1"
+    digest: "sha256:825d7f338cb539fa0e937cab5a68a4859e696cdc851dc06428a3961e6bb16014"
+    pullPolicy: IfNotPresent
+  replicas: 1
+  notice:
+    logPath: /usr/local/zeek/logs/current/notice.log
+  resources:
+    requests:
+      memory: "512Mi"
+      cpu: "500m"
+    limits:
+      memory: "1Gi"
+      cpu: "1000m"
+
+## Arkime full-packet-capture/session viewer. No maintained public image
+## with verifiable provenance was found for this tool (checked Docker Hub
+## + GHCR) — the sub-chart ships as a stub with NO default image; set
+## arkime.image.* before enabling. See charts/arkime/values.yaml.
+arkime:
+  enabled: false
+  image:
+    repository: ""
+    tag: ""
+    digest: ""
+    pullPolicy: IfNotPresent
+  replicas: 1
+  viewer:
+    port: 8005
+  resources:
+    requests:
+      memory: "512Mi"
+      cpu: "500m"
+    limits:
+      memory: "1Gi"
+      cpu: "1000m"
+
+## Strelka file-scanning/YARA pipeline (Target's target/strelka-frontend —
+## the gRPC-facing component a poller submits scans to).
+strelka:
+  enabled: false
+  image:
+    repository: target/strelka-frontend
+    tag: "1.0.1"
+    digest: "sha256:5a713323733240c2028a49e01a008d35aeb955239b75e11d8cb86300369ab524"
+    pullPolicy: IfNotPresent
+  replicas: 1
+  frontend:
+    port: 57314
+  resources:
+    requests:
+      memory: "512Mi"
+      cpu: "500m"
+    limits:
+      memory: "1Gi"
+      cpu: "1000m"
+
+## CAPE sandbox. No safe generic container image exists upstream — CAPE's
+## architecture requires a hypervisor (VirtualBox/KVM) to detonate
+## samples, which is out of scope for a single stub pod. Ships with NO
+## default image; set cape.image.* (and provision the sandbox hosts
+## separately) before enabling. See charts/cape/values.yaml.
+cape:
+  enabled: false
+  image:
+    repository: ""
+    tag: ""
+    digest: ""
+    pullPolicy: IfNotPresent
+  replicas: 1
+  api:
+    port: 8000
+  resources:
+    requests:
+      memory: "512Mi"
+      cpu: "500m"
+    limits:
+      memory: "1Gi"
+      cpu: "1000m"


### PR DESCRIPTION
Slice D Task 5 — package Suricata/Zeek/Arkime/Strelka/CAPE as OPTIONAL, off-by-default Helm sub-charts (establishes the first `dependencies:`+`condition:` pattern in the chart).

- `Chart.yaml` dependencies (each `condition: <tool>.enabled`), `values.yaml` all 5 `enabled: false`, local sub-chart stubs under `charts/`.
- suricata/zeek/strelka SHA256-digest-pinned; arkime/cape have a render-time `fail` guard (no verified public image → operator must supply one). No `latest`.
- Suricata NET_ADMIN/NET_RAW as a documented `ROOT EXCEPTION (approved)`. securityContext + probes + limits per standards.
- `charts/` tracked (scoped .gitignore for generated .tgz only).

Verified: `helm lint` 0 failed; default `helm template` renders 0 tool refs; `--set suricata.enabled=true` renders w/ NET_ADMIN + ROOT EXCEPTION; `helm dependency build` resolves 5 charts.

_Flagged pre-existing (out of scope): `tobogganing.namespace` helper bug + non-canonical values-alpha.yaml naming._

🤖 Generated with [Claude Code](https://claude.com/claude-code)