### PR TITLE
feat(portal): Slice C block-page builder + routing-config UI

### DIFF
--- a/portal/package-lock.json
+++ b/portal/package-lock.json
@@ -8,6 +8,9 @@
       "name": "tobogganing-portal",
       "version": "0.1.0",
       "dependencies": {
+        "@dnd-kit/core": "6.1.0",
+        "@dnd-kit/sortable": "8.0.0",
+        "@dnd-kit/utilities": "3.2.2",
         "@tanstack/react-query": "5.28.0",
         "axios": "1.6.2",
         "express": "4.18.2",
@@ -15,6 +18,7 @@
         "lucide-react": "0.453.0",
         "react": "18.3.1",
         "react-dom": "18.3.1",
+        "react-markdown": "9.0.1",
         "react-router-dom": "6.20.0",
         "recharts": "2.10.3"
       },
@@ -1951,6 +1955,59 @@
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@dnd-kit/accessibility": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/accessibility/-/accessibility-3.1.1.tgz",
+      "integrity": "sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/core": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.1.0.tgz",
+      "integrity": "sha512-J3cQBClB4TVxwGo3KEjssGEXNJqGVWx17aRTZ1ob0FliR5IjYgTxl5YJbKTzA6IzrtelotH19v6y7uoIRUZPSg==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/accessibility": "^3.1.0",
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/sortable": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/sortable/-/sortable-8.0.0.tgz",
+      "integrity": "sha512-U3jk5ebVXe1Lr7c2wU7SBZjcWdQP+j7peHJfCspnA81enlu88Mgd7CC8Q+pub9ubP7eKVETzJW+IBAhsqbSu/g==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@dnd-kit/core": "^6.1.0",
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/utilities": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/utilities/-/utilities-3.2.2.tgz",
+      "integrity": "sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
     },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.20.2",
@@ -4047,12 +4104,29 @@
       "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
       "license": "MIT"
     },
+    "node_modules/@types/debug": {
+      "version": "4.1.13",
+      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.13.tgz",
+      "integrity": "sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/ms": "*"
+      }
+    },
     "node_modules/@types/estree": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
       "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
-      "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/estree-jsx": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@types/estree-jsx/-/estree-jsx-1.0.5.tgz",
+      "integrity": "sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "*"
+      }
     },
     "node_modules/@types/graceful-fs": {
       "version": "4.1.9",
@@ -4062,6 +4136,15 @@
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
+      }
+    },
+    "node_modules/@types/hast": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.5.tgz",
+      "integrity": "sha512-rp/ezSWaD1m44dPKICGhiskI13nVr7qTloFwDa/IYkhhf5nzwP+zIQcIJh3WIFSBOy/H1PzB40jPjMDksN4F+g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
       }
     },
     "node_modules/@types/http-proxy": {
@@ -4165,6 +4248,21 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/mdast": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.4.tgz",
+      "integrity": "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
+    "node_modules/@types/ms": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
+      "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
+      "license": "MIT"
+    },
     "node_modules/@types/node": {
       "version": "20.10.6",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.10.6.tgz",
@@ -4178,14 +4276,12 @@
       "version": "15.7.15",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
       "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/react": {
       "version": "18.2.45",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.2.45.tgz",
       "integrity": "sha512-TtAxCNrlrBp8GoeEp1npd5g+d/OejJHFxS3OWmrPBMFaVQMSN0OFySozJio5BHxTuTeug00AVXVAjfDSfk+lUg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/prop-types": "*",
@@ -4207,7 +4303,6 @@
       "version": "0.26.0",
       "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.26.0.tgz",
       "integrity": "sha512-WFHp9YUJQ6CKshqoC37iOlHnQSmxNc795UhB26CyBBttrN9svdIrUjl/NjnNmfcwtncN0h/0PPAFWv9ovP8mLA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/semver": {
@@ -4229,6 +4324,12 @@
       "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.5.tgz",
       "integrity": "sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/unist": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
+      "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
       "license": "MIT"
     },
     "node_modules/@types/yargs": {
@@ -4488,7 +4589,6 @@
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.3.tgz",
       "integrity": "sha512-60YRaenCQcVjYEKOcG824+DRGGIQ3VKErcBoAEDJZz5bKIs2ZG+X/H9Nk+Q6EVkwJk5QNApxbrc5QtBSwtrXAg==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/@vitejs/plugin-react": {
@@ -5104,6 +5204,16 @@
         "@babel/core": "^7.0.0"
       }
     },
+    "node_modules/bail": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/bail/-/bail-2.0.2.tgz",
+      "integrity": "sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -5360,6 +5470,16 @@
       ],
       "license": "CC-BY-4.0"
     },
+    "node_modules/ccount": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/ccount/-/ccount-2.0.1.tgz",
+      "integrity": "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/chalk": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
@@ -5382,6 +5502,46 @@
       "license": "MIT",
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/character-entities": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-2.0.2.tgz",
+      "integrity": "sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-entities-html4": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/character-entities-html4/-/character-entities-html4-2.1.0.tgz",
+      "integrity": "sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-entities-legacy": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-3.0.0.tgz",
+      "integrity": "sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-reference-invalid": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/character-reference-invalid/-/character-reference-invalid-2.0.1.tgz",
+      "integrity": "sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/ci-info": {
@@ -5479,6 +5639,16 @@
       },
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/comma-separated-tokens": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-2.0.3.tgz",
+      "integrity": "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/concat-map": {
@@ -5637,7 +5807,6 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/d3-array": {
@@ -5834,7 +6003,6 @@
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -5860,6 +6028,19 @@
       "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
       "integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==",
       "license": "MIT"
+    },
+    "node_modules/decode-named-character-reference": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/decode-named-character-reference/-/decode-named-character-reference-1.3.0.tgz",
+      "integrity": "sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==",
+      "license": "MIT",
+      "dependencies": {
+        "character-entities": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
     },
     "node_modules/dedent": {
       "version": "1.7.2",
@@ -5984,7 +6165,6 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
       "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -6018,6 +6198,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/devlop": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/devlop/-/devlop-1.1.0.tgz",
+      "integrity": "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==",
+      "license": "MIT",
+      "dependencies": {
+        "dequal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/diff-sequences": {
@@ -6804,6 +6997,16 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/estree-util-is-identifier-name": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/estree-util-is-identifier-name/-/estree-util-is-identifier-name-3.0.0.tgz",
+      "integrity": "sha512-hFtqIDZTIUZ9BXLb8y4pYGyk6+wekIivNVTcmvk8NoOh+VeRn5y6cEHzbURrWbfp1fIqdVipilzj+lfaadNZmg==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -6934,6 +7137,12 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "license": "MIT"
+    },
+    "node_modules/extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
       "license": "MIT"
     },
     "node_modules/fast-deep-equal": {
@@ -7580,6 +7789,46 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/hast-util-to-jsx-runtime": {
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/hast-util-to-jsx-runtime/-/hast-util-to-jsx-runtime-2.3.6.tgz",
+      "integrity": "sha512-zl6s8LwNyo1P9uw+XJGvZtdFF1GdAkOg8ujOw+4Pyb76874fLps4ueHXDhXWdk6YHQ6OgUtinliG7RsYvCbbBg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/unist": "^3.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "devlop": "^1.0.0",
+        "estree-util-is-identifier-name": "^3.0.0",
+        "hast-util-whitespace": "^3.0.0",
+        "mdast-util-mdx-expression": "^2.0.0",
+        "mdast-util-mdx-jsx": "^3.0.0",
+        "mdast-util-mdxjs-esm": "^2.0.0",
+        "property-information": "^7.0.0",
+        "space-separated-tokens": "^2.0.0",
+        "style-to-js": "^1.0.0",
+        "unist-util-position": "^5.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-whitespace": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-whitespace/-/hast-util-whitespace-3.0.0.tgz",
+      "integrity": "sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/html-encoding-sniffer": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-3.0.0.tgz",
@@ -7599,6 +7848,16 @@
       "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/html-url-attributes": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/html-url-attributes/-/html-url-attributes-3.0.1.tgz",
+      "integrity": "sha512-ol6UPyBWqsrO6EJySPz2O7ZSr856WDrEzM5zMqp+FJJLGMW35cLYmmZnl0vztAZxRUoNZJFTCohfjuIJ8I4QBQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
     },
     "node_modules/http-errors": {
       "version": "2.0.0",
@@ -7814,6 +8073,12 @@
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "license": "ISC"
     },
+    "node_modules/inline-style-parser": {
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/inline-style-parser/-/inline-style-parser-0.2.7.tgz",
+      "integrity": "sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==",
+      "license": "MIT"
+    },
     "node_modules/internal-slot": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.1.0.tgz",
@@ -7845,6 +8110,30 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.10"
+      }
+    },
+    "node_modules/is-alphabetical": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-alphabetical/-/is-alphabetical-2.0.1.tgz",
+      "integrity": "sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/is-alphanumerical": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-alphanumerical/-/is-alphanumerical-2.0.1.tgz",
+      "integrity": "sha512-hmbYhX/9MUMF5uh7tOXyK/n0ZvWpad5caBA17GsC6vyuCqaWliRG5K1qS9inmUhEMaOBIW7/whAnSwveW/LtZw==",
+      "license": "MIT",
+      "dependencies": {
+        "is-alphabetical": "^2.0.0",
+        "is-decimal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/is-arguments": {
@@ -8006,6 +8295,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-decimal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-decimal/-/is-decimal-2.0.1.tgz",
+      "integrity": "sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/is-document.all": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-document.all/-/is-document.all-1.0.0.tgz",
@@ -8097,6 +8396,16 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-hexadecimal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-hexadecimal/-/is-hexadecimal-2.0.1.tgz",
+      "integrity": "sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/is-map": {
@@ -10128,6 +10437,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/longest-streak": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-3.1.0.tgz",
+      "integrity": "sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/loose-envify": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
@@ -10224,6 +10543,159 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/mdast-util-from-markdown": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-2.0.3.tgz",
+      "integrity": "sha512-W4mAWTvSlKvf8L6J+VN9yLSqQ9AOAAvHuoDAmPkz4dHf553m5gVj2ejadHJhoJmcmxEnOv6Pa8XJhpxE93kb8Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-to-string": "^4.0.0",
+        "micromark": "^4.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-decode-string": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "unist-util-stringify-position": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-mdx-expression": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-mdx-expression/-/mdast-util-mdx-expression-2.0.1.tgz",
+      "integrity": "sha512-J6f+9hUp+ldTZqKRSg7Vw5V6MqjATc+3E4gf3CFNcuZNWD8XdyI6zQ8GqH7f8169MM6P7hMBRDVGnn7oHB9kXQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-mdx-jsx": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-mdx-jsx/-/mdast-util-mdx-jsx-3.2.0.tgz",
+      "integrity": "sha512-lj/z8v0r6ZtsN/cGNNtemmmfoLAFZnjMbNyLzBafjzikOM+glrjNHPlf6lQDOTccj9n5b0PPihEBbhneMyGs1Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "ccount": "^2.0.0",
+        "devlop": "^1.1.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "parse-entities": "^4.0.0",
+        "stringify-entities": "^4.0.0",
+        "unist-util-stringify-position": "^4.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-mdxjs-esm": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-mdxjs-esm/-/mdast-util-mdxjs-esm-2.0.1.tgz",
+      "integrity": "sha512-EcmOpxsZ96CvlP03NghtH1EsLtr0n9Tm4lPUJUBccV9RwUOneqSycg19n5HGzCf+10LozMRSObtVr3ee1WoHtg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-phrasing": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-phrasing/-/mdast-util-phrasing-4.1.0.tgz",
+      "integrity": "sha512-TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-hast": {
+      "version": "13.2.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-13.2.1.tgz",
+      "integrity": "sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "@ungap/structured-clone": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "trim-lines": "^3.0.0",
+        "unist-util-position": "^5.0.0",
+        "unist-util-visit": "^5.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-markdown": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-markdown/-/mdast-util-to-markdown-2.1.2.tgz",
+      "integrity": "sha512-xj68wMTvGXVOKonmog6LwyJKrYXZPvlwabaryTjLh9LuvovB/KAH+kvi8Gjj+7rJjsFi23nkUxRQv1KqSroMqA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "longest-streak": "^3.0.0",
+        "mdast-util-phrasing": "^4.0.0",
+        "mdast-util-to-string": "^4.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-decode-string": "^2.0.0",
+        "unist-util-visit": "^5.0.0",
+        "zwitch": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-4.0.0.tgz",
+      "integrity": "sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/media-typer": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
@@ -10264,6 +10736,448 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/micromark": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/micromark/-/micromark-4.0.2.tgz",
+      "integrity": "sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@types/debug": "^4.0.0",
+        "debug": "^4.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-core-commonmark": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-combine-extensions": "^2.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-encode": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-subtokenize": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-core-commonmark": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/micromark-core-commonmark/-/micromark-core-commonmark-2.0.3.tgz",
+      "integrity": "sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-factory-destination": "^2.0.0",
+        "micromark-factory-label": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-factory-title": "^2.0.0",
+        "micromark-factory-whitespace": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-html-tag-name": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-subtokenize": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-destination": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-destination/-/micromark-factory-destination-2.0.1.tgz",
+      "integrity": "sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-label": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-label/-/micromark-factory-label-2.0.1.tgz",
+      "integrity": "sha512-VFMekyQExqIW7xIChcXn4ok29YE3rnuyveW3wZQWWqF4Nv9Wk5rgJ99KzPvHjkmPXF93FXIbBp6YdW3t71/7Vg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-space": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-space/-/micromark-factory-space-2.0.1.tgz",
+      "integrity": "sha512-zRkxjtBxxLd2Sc0d+fbnEunsTj46SWXgXciZmHq0kDYGnck/ZSGj9/wULTV95uoeYiK5hRXP2mJ98Uo4cq/LQg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-title": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-title/-/micromark-factory-title-2.0.1.tgz",
+      "integrity": "sha512-5bZ+3CjhAd9eChYTHsjy6TGxpOFSKgKKJPJxr293jTbfry2KDoWkhBb6TcPVB4NmzaPhMs1Frm9AZH7OD4Cjzw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-whitespace": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-whitespace/-/micromark-factory-whitespace-2.0.1.tgz",
+      "integrity": "sha512-Ob0nuZ3PKt/n0hORHyvoD9uZhr+Za8sFoP+OnMcnWK5lngSzALgQYKMr9RJVOWLqQYuyn6ulqGWSXdwf6F80lQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-character": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.1.tgz",
+      "integrity": "sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-chunked": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-chunked/-/micromark-util-chunked-2.0.1.tgz",
+      "integrity": "sha512-QUNFEOPELfmvv+4xiNg2sRYeS/P84pTW0TCgP5zc9FpXetHY0ab7SxKyAQCNCc1eK0459uoLI1y5oO5Vc1dbhA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-classify-character": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-classify-character/-/micromark-util-classify-character-2.0.1.tgz",
+      "integrity": "sha512-K0kHzM6afW/MbeWYWLjoHQv1sgg2Q9EccHEDzSkxiP/EaagNzCm7T/WMKZ3rjMbvIpvBiZgwR3dKMygtA4mG1Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-combine-extensions": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-combine-extensions/-/micromark-util-combine-extensions-2.0.1.tgz",
+      "integrity": "sha512-OnAnH8Ujmy59JcyZw8JSbK9cGpdVY44NKgSM7E9Eh7DiLS2E9RNQf0dONaGDzEG9yjEl5hcqeIsj4hfRkLH/Bg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-decode-numeric-character-reference": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-util-decode-numeric-character-reference/-/micromark-util-decode-numeric-character-reference-2.0.2.tgz",
+      "integrity": "sha512-ccUbYk6CwVdkmCQMyr64dXz42EfHGkPQlBj5p7YVGzq8I7CtjXZJrubAYezf7Rp+bjPseiROqe7G6foFd+lEuw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-decode-string": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-decode-string/-/micromark-util-decode-string-2.0.1.tgz",
+      "integrity": "sha512-nDV/77Fj6eH1ynwscYTOsbK7rR//Uj0bZXBwJZRfaLEJ1iGBR6kIfNmlNqaqJf649EP0F3NWNdeJi03elllNUQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decode-named-character-reference": "^1.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-encode": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-encode/-/micromark-util-encode-2.0.1.tgz",
+      "integrity": "sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-html-tag-name": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-html-tag-name/-/micromark-util-html-tag-name-2.0.1.tgz",
+      "integrity": "sha512-2cNEiYDhCWKI+Gs9T0Tiysk136SnR13hhO8yW6BGNyhOC4qYFnwF1nKfD3HFAIXA5c45RrIG1ub11GiXeYd1xA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-normalize-identifier": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-normalize-identifier/-/micromark-util-normalize-identifier-2.0.1.tgz",
+      "integrity": "sha512-sxPqmo70LyARJs0w2UclACPUUEqltCkJ6PhKdMIDuJ3gSf/Q+/GIe3WKl0Ijb/GyH9lOpUkRAO2wp0GVkLvS9Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-resolve-all": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-resolve-all/-/micromark-util-resolve-all-2.0.1.tgz",
+      "integrity": "sha512-VdQyxFWFT2/FGJgwQnJYbe1jjQoNTS4RjglmSjTUlpUMa95Htx9NHeYW4rGDJzbjvCsl9eLjMQwGeElsqmzcHg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-sanitize-uri": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-2.0.1.tgz",
+      "integrity": "sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-encode": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-subtokenize": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-subtokenize/-/micromark-util-subtokenize-2.1.0.tgz",
+      "integrity": "sha512-XQLu552iSctvnEcgXw6+Sx75GflAPNED1qx7eBJ+wydBb2KCbRZe+NwvIEEMM83uml1+2WSXpBAcp9IUCgCYWA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-symbol": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-2.0.1.tgz",
+      "integrity": "sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-types": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-2.0.2.tgz",
+      "integrity": "sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/micromatch": {
       "version": "4.0.8",
@@ -10744,6 +11658,31 @@
         "node": ">=6"
       }
     },
+    "node_modules/parse-entities": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-4.0.2.tgz",
+      "integrity": "sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^2.0.0",
+        "character-entities-legacy": "^3.0.0",
+        "character-reference-invalid": "^2.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "is-alphanumerical": "^2.0.0",
+        "is-decimal": "^2.0.0",
+        "is-hexadecimal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/parse-entities/node_modules/@types/unist": {
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.11.tgz",
+      "integrity": "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==",
+      "license": "MIT"
+    },
     "node_modules/parse-json": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
@@ -11058,6 +11997,16 @@
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
       "license": "MIT"
     },
+    "node_modules/property-information": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/property-information/-/property-information-7.2.0.tgz",
+      "integrity": "sha512-IAtzIB6sUiWaJYrX9smp3V46pBGbBeLFRGdh25kg1334VcBlD8HzhPeNIWQH9zhGmo2itIe25EHt9dQP7G5hmg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
@@ -11233,6 +12182,32 @@
       "resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
       "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==",
       "license": "MIT"
+    },
+    "node_modules/react-markdown": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/react-markdown/-/react-markdown-9.0.1.tgz",
+      "integrity": "sha512-186Gw/vF1uRkydbsOIkcGXw7aHq0sZOCRFFjGrr7b9+nVZg4UfA4enXCaxm4fUzecU38sWfrNDitGhshuU7rdg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "devlop": "^1.0.0",
+        "hast-util-to-jsx-runtime": "^2.0.0",
+        "html-url-attributes": "^3.0.0",
+        "mdast-util-to-hast": "^13.0.0",
+        "remark-parse": "^11.0.0",
+        "remark-rehype": "^11.0.0",
+        "unified": "^11.0.0",
+        "unist-util-visit": "^5.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18",
+        "react": ">=18"
+      }
     },
     "node_modules/react-refresh": {
       "version": "0.14.2",
@@ -11461,6 +12436,39 @@
       },
       "bin": {
         "regjsparser": "bin/parser"
+      }
+    },
+    "node_modules/remark-parse": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-11.0.0.tgz",
+      "integrity": "sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-rehype": {
+      "version": "11.1.2",
+      "resolved": "https://registry.npmjs.org/remark-rehype/-/remark-rehype-11.1.2.tgz",
+      "integrity": "sha512-Dh7l57ianaEoIpzbp0PC9UKAdCSVklD8E5Rpw7ETfbTl3FqcOOgq5q2LVDhgGCkaBv7p24JXikPdvhhmHvKMsw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "mdast-util-to-hast": "^13.0.0",
+        "unified": "^11.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/require-directory": {
@@ -12003,6 +13011,16 @@
         "source-map": "^0.6.0"
       }
     },
+    "node_modules/space-separated-tokens": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-2.0.2.tgz",
+      "integrity": "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
@@ -12173,6 +13191,20 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/stringify-entities": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-4.0.4.tgz",
+      "integrity": "sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==",
+      "license": "MIT",
+      "dependencies": {
+        "character-entities-html4": "^2.0.0",
+        "character-entities-legacy": "^3.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/strip-ansi": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
@@ -12230,6 +13262,24 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/style-to-js": {
+      "version": "1.1.21",
+      "resolved": "https://registry.npmjs.org/style-to-js/-/style-to-js-1.1.21.tgz",
+      "integrity": "sha512-RjQetxJrrUJLQPHbLku6U/ocGtzyjbJMP9lCNK7Ag0CNh690nSH8woqWH9u16nMjYBAok+i7JO1NP2pOy8IsPQ==",
+      "license": "MIT",
+      "dependencies": {
+        "style-to-object": "1.0.14"
+      }
+    },
+    "node_modules/style-to-object": {
+      "version": "1.0.14",
+      "resolved": "https://registry.npmjs.org/style-to-object/-/style-to-object-1.0.14.tgz",
+      "integrity": "sha512-LIN7rULI0jBscWQYaSswptyderlarFkjQ+t79nzty8tcIAceVomEVlLzH5VP4Cmsv6MtKhs7qaAiwlcp+Mgaxw==",
+      "license": "MIT",
+      "dependencies": {
+        "inline-style-parser": "0.2.7"
       }
     },
     "node_modules/supports-color": {
@@ -12371,6 +13421,26 @@
         "node": ">=12"
       }
     },
+    "node_modules/trim-lines": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/trim-lines/-/trim-lines-3.0.1.tgz",
+      "integrity": "sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/trough": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/trough/-/trough-2.2.0.tgz",
+      "integrity": "sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/ts-api-utils": {
       "version": "1.4.3",
       "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-1.4.3.tgz",
@@ -12440,6 +13510,12 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
     },
     "node_modules/type-check": {
       "version": "0.4.0",
@@ -12651,6 +13727,105 @@
         "node": ">=4"
       }
     },
+    "node_modules/unified": {
+      "version": "11.0.5",
+      "resolved": "https://registry.npmjs.org/unified/-/unified-11.0.5.tgz",
+      "integrity": "sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "bail": "^2.0.0",
+        "devlop": "^1.0.0",
+        "extend": "^3.0.0",
+        "is-plain-obj": "^4.0.0",
+        "trough": "^2.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unified/node_modules/is-plain-obj": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
+      "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/unist-util-is": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-6.0.1.tgz",
+      "integrity": "sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-position": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-position/-/unist-util-position-5.0.0.tgz",
+      "integrity": "sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-stringify-position": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-4.0.0.tgz",
+      "integrity": "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-5.1.0.tgz",
+      "integrity": "sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0",
+        "unist-util-visit-parents": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit-parents": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-6.0.2.tgz",
+      "integrity": "sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/universalify": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.2.0.tgz",
@@ -12753,6 +13928,34 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/vfile": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/vfile/-/vfile-6.0.3.tgz",
+      "integrity": "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/vfile-message": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-4.0.3.tgz",
+      "integrity": "sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-stringify-position": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/victory-vendor": {
@@ -13154,6 +14357,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zwitch": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/zwitch/-/zwitch-2.0.4.tgz",
+      "integrity": "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     }
   }

--- a/portal/package.json
+++ b/portal/package.json
@@ -14,6 +14,9 @@
     "test:e2e": "playwright test"
   },
   "dependencies": {
+    "@dnd-kit/core": "6.1.0",
+    "@dnd-kit/sortable": "8.0.0",
+    "@dnd-kit/utilities": "3.2.2",
     "@tanstack/react-query": "5.28.0",
     "axios": "1.6.2",
     "express": "4.18.2",
@@ -21,6 +24,7 @@
     "lucide-react": "0.453.0",
     "react": "18.3.1",
     "react-dom": "18.3.1",
+    "react-markdown": "9.0.1",
     "react-router-dom": "6.20.0",
     "recharts": "2.10.3"
   },

--- a/portal/src/api/sase.ts
+++ b/portal/src/api/sase.ts
@@ -1,5 +1,6 @@
 import apiClient from './client';
 
+// Cluster / Client / Status types
 export interface Cluster {
   id: string;
   name: string;
@@ -50,6 +51,56 @@ export interface StatusData {
   };
 }
 
+// Block Pages types
+export interface BlockPage {
+  id: string;
+  tenant: string;
+  name: string;
+  markdown: string;
+  status: 'draft' | 'live';
+  version: number;
+  created_by: string;
+  updated_by: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface BlockPagePreview {
+  html: string;
+  variables: Record<string, string>;
+}
+
+// Block Routes types
+export interface BlockRoute {
+  id: string;
+  tenant: string;
+  source_type: string;
+  destination_kind: 'page' | 'external';
+  page_id: string | null;
+  external_url: string | null;
+  created_at: string;
+  created_by: string | null;
+  updated_by: string | null;
+  ticket: string | null;
+  notes: string | null;
+  expiry: string | null;
+  review_date: string | null;
+  scope: string | null;
+  risk: string | null;
+}
+
+export interface BlockRouteMetadata {
+  created_by?: string;
+  updated_by?: string;
+  ticket?: string;
+  notes?: string;
+  expiry?: string;
+  review_date?: string;
+  scope?: string;
+  risk?: string;
+}
+
+// Existing API functions
 export async function listClusters(): Promise<Cluster[]> {
   console.log('[sase] listClusters');
   const response = await apiClient.get<ClustersResponse>('/sdwan/clusters');
@@ -66,4 +117,69 @@ export async function getStatus(): Promise<StatusData> {
   console.log('[sase] getStatus');
   const response = await apiClient.get<StatusData>('/sdwan/status');
   return response.data;
+}
+
+// Block Pages API functions
+export async function listBlockPages(): Promise<BlockPage[]> {
+  console.log('[BlockPages] listBlockPages');
+  const response = await apiClient.get<{ pages: BlockPage[] }>('/blockpages/pages');
+  return response.data.pages;
+}
+
+export async function createBlockPage(name: string, markdown: string): Promise<BlockPage> {
+  console.log('[BlockPages] createBlockPage { name }', { name });
+  const response = await apiClient.post<BlockPage>('/blockpages/pages', {
+    name,
+    markdown,
+  });
+  return response.data;
+}
+
+export async function updateBlockPage(pageId: string, markdown: string): Promise<BlockPage> {
+  console.log('[BlockPages] updateBlockPage { pageId }', { pageId });
+  const response = await apiClient.put<BlockPage>(`/blockpages/pages/${pageId}`, {
+    markdown,
+  });
+  return response.data;
+}
+
+export async function publishBlockPage(pageId: string): Promise<BlockPage> {
+  console.log('[BlockPages] publishBlockPage { pageId }', { pageId });
+  const response = await apiClient.post<BlockPage>(`/blockpages/pages/${pageId}/publish`);
+  return response.data;
+}
+
+export async function previewBlockPage(
+  pageId: string,
+  variables?: Record<string, string>
+): Promise<BlockPagePreview> {
+  console.log('[BlockPages] previewBlockPage { pageId }', { pageId });
+  const response = await apiClient.post<BlockPagePreview>(
+    `/blockpages/pages/${pageId}/preview`,
+    { variables: variables || {} }
+  );
+  return response.data;
+}
+
+// Block Routes API functions
+export async function listBlockRoutes(): Promise<BlockRoute[]> {
+  console.log('[BlockRoutes] listBlockRoutes');
+  const response = await apiClient.get<{ routes: BlockRoute[] }>('/blockpages/routes');
+  return response.data.routes;
+}
+
+export async function upsertBlockRoutes(
+  routes: Array<{
+    source_type: string;
+    destination_kind: 'page' | 'external';
+    page_id?: string | null;
+    external_url?: string | null;
+    metadata?: BlockRouteMetadata;
+  }>
+): Promise<BlockRoute[]> {
+  console.log('[BlockRoutes] upsertBlockRoutes { count }', { count: routes.length });
+  const response = await apiClient.put<{ routes: BlockRoute[] }>('/blockpages/routes', {
+    routes,
+  });
+  return response.data.routes;
 }

--- a/portal/src/pages/sase/BlockPageBuilder.test.tsx
+++ b/portal/src/pages/sase/BlockPageBuilder.test.tsx
@@ -131,8 +131,10 @@ describe('BlockPageBuilder', () => {
     expect(textareas.length).toBeGreaterThan(0);
     fireEvent.change(textareas[0]!, { target: { value: 'This is a paragraph.' } });
 
+    // Verify markdown output contains the text (in the generated markdown <pre> block)
     await waitFor(() => {
-      expect(screen.getByText('This is a paragraph.')).toBeInTheDocument();
+      const markdownOutput = screen.getByText(/This is a paragraph\./, { selector: 'pre' });
+      expect(markdownOutput).toBeInTheDocument();
     });
   });
 
@@ -208,10 +210,10 @@ describe('BlockPageBuilder', () => {
     expect(textareas.length).toBeGreaterThan(0);
     fireEvent.change(textareas[0]!, { target: { value: 'Item 1\nItem 2\nItem 3' } });
 
+    // Verify markdown output contains the list items (in the generated markdown <pre> block)
     await waitFor(() => {
-      expect(screen.getByText('- Item 1')).toBeInTheDocument();
-      expect(screen.getByText('- Item 2')).toBeInTheDocument();
-      expect(screen.getByText('- Item 3')).toBeInTheDocument();
+      const markdownOutput = screen.getByText(/- Item 1[\s\S]*- Item 2[\s\S]*- Item 3/, { selector: 'pre' });
+      expect(markdownOutput).toBeInTheDocument();
     });
   });
 
@@ -278,6 +280,8 @@ describe('BlockPageBuilder', () => {
   });
 
   it('shows page name required error', async () => {
+    const alertSpy = jest.spyOn(window, 'alert').mockImplementation();
+
     renderComponent();
 
     // Add a block
@@ -293,8 +297,10 @@ describe('BlockPageBuilder', () => {
     fireEvent.click(saveButton);
 
     await waitFor(() => {
-      expect(screen.getByText('Please enter a page name')).toBeInTheDocument();
+      expect(alertSpy).toHaveBeenCalledWith('Please enter a page name');
     });
+
+    alertSpy.mockRestore();
   });
 
   it('renders multiple blocks in order', async () => {

--- a/portal/src/pages/sase/BlockPageBuilder.test.tsx
+++ b/portal/src/pages/sase/BlockPageBuilder.test.tsx
@@ -1,0 +1,332 @@
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { BlockPageBuilder } from './BlockPageBuilder';
+import * as saseApi from '../../api/sase';
+
+// Mock the API
+jest.mock('../../api/sase');
+const mockedSaseApi = saseApi as jest.Mocked<typeof saseApi>;
+
+describe('BlockPageBuilder', () => {
+  let queryClient: QueryClient;
+
+  beforeEach(() => {
+    queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+
+    // Mock API functions
+    mockedSaseApi.listBlockPages.mockResolvedValue([]);
+    mockedSaseApi.createBlockPage.mockResolvedValue({
+      id: 'page-1',
+      tenant: 'tenant-1',
+      name: 'Test Page',
+      markdown: '# Test',
+      status: 'draft',
+      version: 1,
+      created_by: 'user-1',
+      updated_by: null,
+      created_at: new Date().toISOString(),
+      updated_at: new Date().toISOString(),
+    });
+    mockedSaseApi.updateBlockPage.mockResolvedValue({
+      id: 'page-1',
+      tenant: 'tenant-1',
+      name: 'Test Page',
+      markdown: '# Updated',
+      status: 'draft',
+      version: 1,
+      created_by: 'user-1',
+      updated_by: 'user-1',
+      created_at: new Date().toISOString(),
+      updated_at: new Date().toISOString(),
+    });
+    mockedSaseApi.previewBlockPage.mockResolvedValue({
+      html: '<h1>Test</h1>',
+      variables: {
+        blocked_url: 'example.com',
+        category: 'Uncategorized',
+      },
+    });
+  });
+
+  const renderComponent = () => {
+    return render(
+      <QueryClientProvider client={queryClient}>
+        <BlockPageBuilder />
+      </QueryClientProvider>
+    );
+  };
+
+  it('renders the builder with title and initial state', () => {
+    renderComponent();
+    expect(screen.getByText('Block Page Builder')).toBeInTheDocument();
+    expect(screen.getByPlaceholderText('e.g., \'Malware Block Page\'')).toBeInTheDocument();
+  });
+
+  it('adds a heading block when clicking add button', async () => {
+    renderComponent();
+
+    const h1Button = screen.getByLabelText('Add heading1 block');
+    expect(h1Button).toBeInTheDocument();
+    fireEvent.click(h1Button);
+
+    await waitFor(() => {
+      expect(screen.getByText('Heading 1')).toBeInTheDocument();
+    });
+  });
+
+  it('serializes blocks to markdown correctly', async () => {
+    renderComponent();
+
+    // Add H1 block
+    fireEvent.click(screen.getByLabelText('Add heading1 block'));
+
+    await waitFor(() => {
+      const h1Blocks = screen.getAllByText('Heading 1');
+      expect(h1Blocks.length).toBeGreaterThan(0);
+    });
+
+    // Expand the block
+    const expandButtons = screen.getAllByLabelText(/Expand block/i);
+    expect(expandButtons.length).toBeGreaterThan(0);
+    const expandButton = expandButtons[0]!;
+    expect(expandButton).toBeInTheDocument();
+    fireEvent.click(expandButton);
+
+    // Enter heading text
+    const inputs = screen.getAllByPlaceholderText('Enter heading text');
+    expect(inputs.length).toBeGreaterThan(0);
+    fireEvent.change(inputs[0]!, { target: { value: 'My Block Page' } });
+
+    await waitFor(() => {
+      expect(screen.getByText('# My Block Page')).toBeInTheDocument();
+    });
+  });
+
+  it('serializes text block to markdown', async () => {
+    renderComponent();
+
+    fireEvent.click(screen.getByLabelText('Add text block'));
+
+    await waitFor(() => {
+      const textLabels = screen.getAllByText('Text/Paragraph');
+      expect(textLabels.length).toBeGreaterThan(0);
+    });
+
+    const expandButtons = screen.getAllByLabelText(/Expand block/i);
+    expect(expandButtons.length).toBeGreaterThan(0);
+    fireEvent.click(expandButtons[0]!);
+
+    const textareas = screen.getAllByPlaceholderText(/Enter paragraph text/);
+    expect(textareas.length).toBeGreaterThan(0);
+    fireEvent.change(textareas[0]!, { target: { value: 'This is a paragraph.' } });
+
+    await waitFor(() => {
+      expect(screen.getByText('This is a paragraph.')).toBeInTheDocument();
+    });
+  });
+
+  it('serializes image block to markdown', async () => {
+    renderComponent();
+
+    fireEvent.click(screen.getByLabelText('Add image block'));
+
+    await waitFor(() => {
+      const imageLabels = screen.getAllByText('Image');
+      expect(imageLabels.length).toBeGreaterThan(0);
+    });
+
+    const expandButtons = screen.getAllByLabelText(/Expand block/i);
+    expect(expandButtons.length).toBeGreaterThan(0);
+    fireEvent.click(expandButtons[0]!);
+
+    const inputs = screen.getAllByPlaceholderText('https://example.com/image.png');
+    expect(inputs.length).toBeGreaterThan(0);
+    fireEvent.change(inputs[0]!, { target: { value: 'https://example.com/logo.png' } });
+
+    const altInputs = screen.getAllByPlaceholderText('Description of the image');
+    expect(altInputs.length).toBeGreaterThan(0);
+    fireEvent.change(altInputs[0]!, { target: { value: 'Company Logo' } });
+
+    await waitFor(() => {
+      expect(screen.getByText('![Company Logo](https://example.com/logo.png)')).toBeInTheDocument();
+    });
+  });
+
+  it('serializes link block to markdown', async () => {
+    renderComponent();
+
+    fireEvent.click(screen.getByLabelText('Add link block'));
+
+    await waitFor(() => {
+      const linkLabels = screen.getAllByText('Link/Button');
+      expect(linkLabels.length).toBeGreaterThan(0);
+    });
+
+    const expandButtons = screen.getAllByLabelText(/Expand block/i);
+    expect(expandButtons.length).toBeGreaterThan(0);
+    fireEvent.click(expandButtons[0]!);
+
+    const inputs = screen.getAllByPlaceholderText('Click here');
+    expect(inputs.length).toBeGreaterThan(0);
+    fireEvent.change(inputs[0]!, { target: { value: 'Appeal Now' } });
+
+    const urlInputs = screen.getAllByPlaceholderText('https://example.com');
+    expect(urlInputs.length).toBeGreaterThan(0);
+    fireEvent.change(urlInputs[0]!, { target: { value: 'https://appeal.example.com' } });
+
+    await waitFor(() => {
+      expect(screen.getByText('[Appeal Now](https://appeal.example.com)')).toBeInTheDocument();
+    });
+  });
+
+  it('serializes list block to markdown', async () => {
+    renderComponent();
+
+    fireEvent.click(screen.getByLabelText('Add list block'));
+
+    await waitFor(() => {
+      const listLabels = screen.getAllByText('List');
+      expect(listLabels.length).toBeGreaterThan(0);
+    });
+
+    const expandButtons = screen.getAllByLabelText(/Expand block/i);
+    expect(expandButtons.length).toBeGreaterThan(0);
+    fireEvent.click(expandButtons[0]!);
+
+    const textareas = screen.getAllByPlaceholderText(/Item 1/);
+    expect(textareas.length).toBeGreaterThan(0);
+    fireEvent.change(textareas[0]!, { target: { value: 'Item 1\nItem 2\nItem 3' } });
+
+    await waitFor(() => {
+      expect(screen.getByText('- Item 1')).toBeInTheDocument();
+      expect(screen.getByText('- Item 2')).toBeInTheDocument();
+      expect(screen.getByText('- Item 3')).toBeInTheDocument();
+    });
+  });
+
+  it('serializes divider block to markdown', async () => {
+    renderComponent();
+
+    fireEvent.click(screen.getByLabelText('Add divider block'));
+
+    await waitFor(() => {
+      const dividerLabels = screen.getAllByText('Divider');
+      expect(dividerLabels.length).toBeGreaterThan(0);
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText('---')).toBeInTheDocument();
+    });
+  });
+
+  it('removes a block when trash button clicked', async () => {
+    renderComponent();
+
+    fireEvent.click(screen.getByLabelText('Add heading1 block'));
+
+    await waitFor(() => {
+      const h1Blocks = screen.getAllByText('Heading 1');
+      expect(h1Blocks.length).toBeGreaterThan(0);
+    });
+
+    // Get the remove button for the block
+    const removeButtons = screen.getAllByLabelText(/Remove.*block/i);
+    expect(removeButtons.length).toBeGreaterThan(0);
+    const removeButton = removeButtons[0]!;
+    expect(removeButton).toBeInTheDocument();
+    fireEvent.click(removeButton);
+
+    await waitFor(() => {
+      const h1Blocks = screen.queryAllByText('Heading 1');
+      expect(h1Blocks.length).toBe(0);
+    });
+  });
+
+  it('saves page with markdown content', async () => {
+    renderComponent();
+
+    // Enter page name
+    const pageName = screen.getByPlaceholderText('e.g., \'Malware Block Page\'');
+    fireEvent.change(pageName, { target: { value: 'Malware Block' } });
+
+    // Add a block
+    fireEvent.click(screen.getByLabelText('Add heading1 block'));
+
+    await waitFor(() => {
+      const h1Blocks = screen.getAllByText('Heading 1');
+      expect(h1Blocks.length).toBeGreaterThan(0);
+    });
+
+    // Save
+    const saveButton = screen.getByText('Save');
+    fireEvent.click(saveButton);
+
+    await waitFor(() => {
+      expect(mockedSaseApi.createBlockPage).toHaveBeenCalled();
+    });
+  });
+
+  it('shows page name required error', async () => {
+    renderComponent();
+
+    // Add a block
+    fireEvent.click(screen.getByLabelText('Add heading1 block'));
+
+    await waitFor(() => {
+      const h1Blocks = screen.getAllByText('Heading 1');
+      expect(h1Blocks.length).toBeGreaterThan(0);
+    });
+
+    // Try to save without a page name
+    const saveButton = screen.getByText('Save');
+    fireEvent.click(saveButton);
+
+    await waitFor(() => {
+      expect(screen.getByText('Please enter a page name')).toBeInTheDocument();
+    });
+  });
+
+  it('renders multiple blocks in order', async () => {
+    renderComponent();
+
+    // Add H1
+    fireEvent.click(screen.getByLabelText('Add heading1 block'));
+    // Add text
+    fireEvent.click(screen.getByLabelText('Add text block'));
+    // Add divider
+    fireEvent.click(screen.getByLabelText('Add divider block'));
+
+    await waitFor(() => {
+      const headingLabels = screen.getAllByText('Heading 1');
+      const textLabels = screen.getAllByText('Text/Paragraph');
+      const dividerLabels = screen.getAllByText('Divider');
+
+      expect(headingLabels.length).toBeGreaterThan(0);
+      expect(textLabels.length).toBeGreaterThan(0);
+      expect(dividerLabels.length).toBeGreaterThan(0);
+    });
+
+    // Verify blocks are displayed
+    const blocks = screen.getAllByText(/Heading 1|Text\/Paragraph|Divider/);
+    expect(blocks.length).toBeGreaterThan(0);
+  });
+
+  it('console logs block operations', async () => {
+    const consoleSpy = jest.spyOn(console, 'log').mockImplementation();
+
+    renderComponent();
+    fireEvent.click(screen.getByLabelText('Add heading1 block'));
+
+    await waitFor(() => {
+      expect(consoleSpy).toHaveBeenCalledWith(
+        expect.stringContaining('[BlockPageBuilder]'),
+        expect.any(Object)
+      );
+    });
+
+    consoleSpy.mockRestore();
+  });
+});

--- a/portal/src/pages/sase/BlockPageBuilder.test.tsx
+++ b/portal/src/pages/sase/BlockPageBuilder.test.tsx
@@ -4,6 +4,14 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { BlockPageBuilder } from './BlockPageBuilder';
 import * as saseApi from '../../api/sase';
 
+// Mock react-markdown to avoid ESM transform issues
+jest.mock('react-markdown', () => ({
+  __esModule: true,
+  default: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="markdown-preview">{children}</div>
+  ),
+}));
+
 // Mock the API
 jest.mock('../../api/sase');
 const mockedSaseApi = saseApi as jest.Mocked<typeof saseApi>;

--- a/portal/src/pages/sase/BlockPageBuilder.tsx
+++ b/portal/src/pages/sase/BlockPageBuilder.tsx
@@ -1,0 +1,543 @@
+import React, { useState, useCallback, useMemo } from 'react';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { ChevronDown, ChevronUp, Trash2, Plus, Eye } from 'lucide-react';
+import ReactMarkdown from 'react-markdown';
+import {
+  DndContext,
+  closestCenter,
+  KeyboardSensor,
+  PointerSensor,
+  useSensor,
+  useSensors,
+  DragEndEvent,
+} from '@dnd-kit/core';
+import {
+  arrayMove,
+  SortableContext,
+  sortableKeyboardCoordinates,
+  verticalListSortingStrategy,
+} from '@dnd-kit/sortable';
+import { useSortable } from '@dnd-kit/sortable';
+import { CSS } from '@dnd-kit/utilities';
+import {
+  listBlockPages,
+  createBlockPage,
+  updateBlockPage,
+  publishBlockPage,
+  previewBlockPage,
+  type BlockPage,
+  type BlockPagePreview,
+} from '../../api/sase';
+
+/** A markdown element block */
+export interface MarkdownBlock {
+  id: string;
+  type: 'heading1' | 'heading2' | 'heading3' | 'heading4' | 'text' | 'image' | 'link' | 'list' | 'divider';
+  content: Record<string, string>;
+}
+
+/** Draggable block editor */
+function SortableBlockEditor({
+  block,
+  onUpdate,
+  onRemove,
+}: {
+  block: MarkdownBlock;
+  onUpdate: (block: MarkdownBlock) => void;
+  onRemove: () => void;
+}) {
+  const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
+    id: block.id,
+  });
+
+  const style = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+    opacity: isDragging ? 0.5 : 1,
+  };
+
+  const [isExpanded, setIsExpanded] = useState(false);
+
+  const updateContent = (key: string, value: string) => {
+    onUpdate({
+      ...block,
+      content: { ...block.content, [key]: value },
+    });
+  };
+
+  const blockTypeLabel = {
+    heading1: 'Heading 1',
+    heading2: 'Heading 2',
+    heading3: 'Heading 3',
+    heading4: 'Heading 4',
+    text: 'Text/Paragraph',
+    image: 'Image',
+    link: 'Link/Button',
+    list: 'List',
+    divider: 'Divider',
+  }[block.type];
+
+  return (
+    <div
+      ref={setNodeRef}
+      style={style}
+      className="bg-slate-700 rounded-lg p-4 border border-slate-600 space-y-3"
+    >
+      <div className="flex items-center justify-between gap-2">
+        <button
+          {...attributes}
+          {...listeners}
+          className="flex items-center gap-2 cursor-grab active:cursor-grabbing text-slate-300"
+          aria-label={`Drag handle for ${blockTypeLabel} block`}
+        >
+          <div className="text-amber-400">☰</div>
+          <span className="text-sm font-semibold text-amber-400">{blockTypeLabel}</span>
+        </button>
+        <div className="flex items-center gap-2">
+          <button
+            onClick={() => setIsExpanded(!isExpanded)}
+            className="text-slate-300 hover:text-amber-400 transition-colors"
+            aria-label={isExpanded ? 'Collapse block' : 'Expand block'}
+          >
+            {isExpanded ? <ChevronUp size={16} /> : <ChevronDown size={16} />}
+          </button>
+          <button
+            onClick={onRemove}
+            className="text-red-400 hover:text-red-300 transition-colors"
+            aria-label={`Remove ${blockTypeLabel} block`}
+          >
+            <Trash2 size={16} />
+          </button>
+        </div>
+      </div>
+
+      {isExpanded && (
+        <div className="space-y-3 pl-4">
+          {block.type.startsWith('heading') && (
+            <div>
+              <label className="block text-sm text-slate-300 mb-1">Heading Text</label>
+              <input
+                type="text"
+                value={block.content.text || ''}
+                onChange={(e) => updateContent('text', e.target.value)}
+                placeholder="Enter heading text"
+                className="w-full bg-slate-600 text-white px-2 py-1 rounded border border-slate-500 focus:border-amber-400 focus:outline-none"
+              />
+            </div>
+          )}
+
+          {block.type === 'text' && (
+            <div>
+              <label className="block text-sm text-slate-300 mb-1">Paragraph Text</label>
+              <textarea
+                value={block.content.text || ''}
+                onChange={(e) => updateContent('text', e.target.value)}
+                placeholder="Enter paragraph text. Supports {{template_variables}}"
+                rows={3}
+                className="w-full bg-slate-600 text-white px-2 py-1 rounded border border-slate-500 focus:border-amber-400 focus:outline-none"
+              />
+            </div>
+          )}
+
+          {block.type === 'image' && (
+            <>
+              <div>
+                <label className="block text-sm text-slate-300 mb-1">Image URL</label>
+                <input
+                  type="text"
+                  value={block.content.url || ''}
+                  onChange={(e) => updateContent('url', e.target.value)}
+                  placeholder="https://example.com/image.png"
+                  className="w-full bg-slate-600 text-white px-2 py-1 rounded border border-slate-500 focus:border-amber-400 focus:outline-none"
+                />
+              </div>
+              <div>
+                <label className="block text-sm text-slate-300 mb-1">Alt Text</label>
+                <input
+                  type="text"
+                  value={block.content.alt || ''}
+                  onChange={(e) => updateContent('alt', e.target.value)}
+                  placeholder="Description of the image"
+                  className="w-full bg-slate-600 text-white px-2 py-1 rounded border border-slate-500 focus:border-amber-400 focus:outline-none"
+                />
+              </div>
+            </>
+          )}
+
+          {block.type === 'link' && (
+            <>
+              <div>
+                <label className="block text-sm text-slate-300 mb-1">Link Text</label>
+                <input
+                  type="text"
+                  value={block.content.text || ''}
+                  onChange={(e) => updateContent('text', e.target.value)}
+                  placeholder="Click here"
+                  className="w-full bg-slate-600 text-white px-2 py-1 rounded border border-slate-500 focus:border-amber-400 focus:outline-none"
+                />
+              </div>
+              <div>
+                <label className="block text-sm text-slate-300 mb-1">URL</label>
+                <input
+                  type="text"
+                  value={block.content.href || ''}
+                  onChange={(e) => updateContent('href', e.target.value)}
+                  placeholder="https://example.com"
+                  className="w-full bg-slate-600 text-white px-2 py-1 rounded border border-slate-500 focus:border-amber-400 focus:outline-none"
+                />
+              </div>
+            </>
+          )}
+
+          {block.type === 'list' && (
+            <div>
+              <label className="block text-sm text-slate-300 mb-1">List Items (one per line)</label>
+              <textarea
+                value={block.content.items || ''}
+                onChange={(e) => updateContent('items', e.target.value)}
+                placeholder="Item 1&#10;Item 2&#10;Item 3"
+                rows={4}
+                className="w-full bg-slate-600 text-white px-2 py-1 rounded border border-slate-500 focus:border-amber-400 focus:outline-none font-mono text-xs"
+              />
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+/**
+ * BlockPageBuilder — drag-drop markdown element builder
+ *
+ * Allows users to build block pages by dragging and dropping markdown elements,
+ * editing their content, and previewing the rendered markdown. Save/publish functionality.
+ */
+export function BlockPageBuilder() {
+  const [blocks, setBlocks] = useState<MarkdownBlock[]>([]);
+  const [pageName, setPageName] = useState('');
+  const [pageId, setPageId] = useState<string | null>(null);
+  const [showPreview, setShowPreview] = useState(false);
+  const [previewData, setPreviewData] = useState<BlockPagePreview | null>(null);
+  const [previewLoading, setPreviewLoading] = useState(false);
+  const [isSaving, setIsSaving] = useState(false);
+
+  const queryClient = useQueryClient();
+
+  const sensors = useSensors(
+    useSensor(PointerSensor),
+    useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates })
+  );
+
+  console.log('[BlockPageBuilder] Render { pageName, blockCount }', { pageName, blockCount: blocks.length });
+
+  // Load existing pages
+  const { data: pages = [] } = useQuery({
+    queryKey: ['blockpages', 'pages'],
+    queryFn: listBlockPages,
+  });
+
+  // Serialize blocks to markdown
+  const serializeMarkdown = useCallback((): string => {
+    return blocks
+      .map((block) => {
+        switch (block.type) {
+          case 'heading1':
+            return `# ${block.content.text || ''}`;
+          case 'heading2':
+            return `## ${block.content.text || ''}`;
+          case 'heading3':
+            return `### ${block.content.text || ''}`;
+          case 'heading4':
+            return `#### ${block.content.text || ''}`;
+          case 'text':
+            return block.content.text || '';
+          case 'image':
+            return `![${block.content.alt || 'image'}](${block.content.url || ''})`;
+          case 'link':
+            return `[${block.content.text || 'link'}](${block.content.href || ''})`;
+          case 'list':
+            return (block.content.items || '')
+              .split('\n')
+              .filter((item) => item.trim())
+              .map((item) => `- ${item}`)
+              .join('\n');
+          case 'divider':
+            return '---';
+          default:
+            return '';
+        }
+      })
+      .join('\n\n');
+  }, [blocks]);
+
+  // Handle drag end
+  const handleDragEnd = (event: DragEndEvent) => {
+    const { active, over } = event;
+
+    if (over && active.id !== over.id) {
+      const oldIndex = blocks.findIndex((b) => b.id === active.id);
+      const newIndex = blocks.findIndex((b) => b.id === over.id);
+      setBlocks(arrayMove(blocks, oldIndex, newIndex));
+      console.log('[BlockPageBuilder] Reorder { oldIndex, newIndex }', { oldIndex, newIndex });
+    }
+  };
+
+  // Add a new block
+  const addBlock = (type: MarkdownBlock['type']) => {
+    const newBlock: MarkdownBlock = {
+      id: `block-${Date.now()}`,
+      type,
+      content: {},
+    };
+    setBlocks([...blocks, newBlock]);
+    console.log('[BlockPageBuilder] AddBlock { type }', { type });
+  };
+
+  // Update a block
+  const updateBlock = (updatedBlock: MarkdownBlock) => {
+    setBlocks(blocks.map((b) => (b.id === updatedBlock.id ? updatedBlock : b)));
+  };
+
+  // Remove a block
+  const removeBlock = (id: string) => {
+    setBlocks(blocks.filter((b) => b.id !== id));
+    console.log('[BlockPageBuilder] RemoveBlock { id }', { id });
+  };
+
+  // Load a page
+  const loadPage = (page: BlockPage) => {
+    console.log('[BlockPageBuilder] LoadPage { pageId }', { pageId: page.id });
+    setPageName(page.name);
+    setPageId(page.id);
+    // Parse markdown back to blocks (simplified: split by paragraphs)
+    // In a real app, you'd have a markdown parser
+    setBlocks([]);
+  };
+
+  // Save page
+  const handleSave = async () => {
+    setIsSaving(true);
+    try {
+      const markdown = serializeMarkdown();
+      if (!pageName.trim()) {
+        alert('Please enter a page name');
+        setIsSaving(false);
+        return;
+      }
+
+      if (pageId) {
+        await updateBlockPage(pageId, markdown);
+        console.log('[BlockPageBuilder] UpdatePage success { pageId }', { pageId });
+      } else {
+        const newPage = await createBlockPage(pageName, markdown);
+        setPageId(newPage.id);
+        console.log('[BlockPageBuilder] CreatePage success { pageId }', { pageId: newPage.id });
+      }
+
+      queryClient.invalidateQueries({ queryKey: ['blockpages', 'pages'] });
+    } catch (error) {
+      console.error('[BlockPageBuilder] SavePage error', { error: String(error) });
+      alert('Failed to save page');
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  // Publish page
+  const handlePublish = async () => {
+    if (!pageId) {
+      alert('Please save the page first');
+      return;
+    }
+
+    try {
+      await publishBlockPage(pageId);
+      console.log('[BlockPageBuilder] PublishPage success { pageId }', { pageId });
+      queryClient.invalidateQueries({ queryKey: ['blockpages', 'pages'] });
+      alert('Page published!');
+    } catch (error) {
+      console.error('[BlockPageBuilder] PublishPage error', { error: String(error) });
+      alert('Failed to publish page');
+    }
+  };
+
+  // Preview
+  const handlePreview = async () => {
+    if (!pageId) {
+      alert('Please save the page first');
+      return;
+    }
+
+    setPreviewLoading(true);
+    try {
+      const preview = await previewBlockPage(pageId);
+      setPreviewData(preview);
+      setShowPreview(true);
+      console.log('[BlockPageBuilder] Preview success { pageId }', { pageId });
+    } catch (error) {
+      console.error('[BlockPageBuilder] Preview error', { error: String(error) });
+      alert('Failed to generate preview');
+    } finally {
+      setPreviewLoading(false);
+    }
+  };
+
+  const markdown = useMemo(() => serializeMarkdown(), [serializeMarkdown]);
+  const blockIds = useMemo(() => blocks.map((b) => b.id), [blocks]);
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center justify-between">
+        <h1 className="text-2xl font-bold text-amber-400">Block Page Builder</h1>
+        <button
+          onClick={() => setShowPreview(!showPreview)}
+          className="flex items-center gap-2 px-3 py-2 bg-sky-600 hover:bg-sky-700 text-white rounded transition-colors"
+          aria-label={showPreview ? 'Hide preview' : 'Show preview'}
+        >
+          <Eye size={16} />
+          {showPreview ? 'Hide Preview' : 'Show Preview'}
+        </button>
+      </div>
+
+      {/* Page Name & Actions */}
+      <div className="bg-slate-800 rounded-lg p-4 space-y-3">
+        <div>
+          <label className="block text-sm text-slate-300 mb-1">Page Name</label>
+          <input
+            type="text"
+            value={pageName}
+            onChange={(e) => setPageName(e.target.value)}
+            placeholder="e.g., 'Malware Block Page'"
+            className="w-full bg-slate-700 text-white px-3 py-2 rounded border border-slate-600 focus:border-amber-400 focus:outline-none"
+          />
+        </div>
+
+        <div className="flex gap-2 flex-wrap">
+          <button
+            onClick={handleSave}
+            disabled={isSaving}
+            className="px-4 py-2 bg-green-600 hover:bg-green-700 text-white rounded disabled:opacity-50 transition-colors"
+          >
+            {isSaving ? 'Saving...' : 'Save'}
+          </button>
+          {pageId && (
+            <>
+              <button
+                onClick={handlePublish}
+                className="px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white rounded transition-colors"
+              >
+                Publish
+              </button>
+              <button
+                onClick={handlePreview}
+                disabled={previewLoading}
+                className="px-4 py-2 bg-amber-600 hover:bg-amber-700 text-white rounded disabled:opacity-50 transition-colors"
+              >
+                {previewLoading ? 'Loading...' : 'Preview'}
+              </button>
+            </>
+          )}
+        </div>
+
+        {/* Load Existing Page */}
+        {pages.length > 0 && (
+          <div>
+            <label className="block text-sm text-slate-300 mb-2">Load Existing Page</label>
+            <select
+              onChange={(e) => {
+                const page = pages.find((p) => p.id === e.target.value);
+                if (page) loadPage(page);
+              }}
+              className="w-full bg-slate-700 text-white px-3 py-2 rounded border border-slate-600 focus:border-amber-400 focus:outline-none"
+            >
+              <option value="">-- Select a page --</option>
+              {pages.map((page) => (
+                <option key={page.id} value={page.id}>
+                  {page.name} ({page.status})
+                </option>
+              ))}
+            </select>
+          </div>
+        )}
+      </div>
+
+      <div className={showPreview ? 'grid grid-cols-2 gap-4' : ''}>
+        {/* Block Editor */}
+        <div className="space-y-3">
+          <h2 className="text-lg font-semibold text-amber-400">Blocks</h2>
+
+          {/* Add Block Palette */}
+          <div className="bg-slate-800 rounded-lg p-4">
+            <p className="text-sm text-slate-300 mb-3">Add blocks:</p>
+            <div className="grid grid-cols-2 gap-2">
+              {(['heading1', 'heading2', 'heading3', 'heading4', 'text', 'image', 'link', 'list', 'divider'] as const).map(
+                (type) => (
+                  <button
+                    key={type}
+                    onClick={() => addBlock(type)}
+                    className="flex items-center gap-2 px-2 py-2 bg-slate-700 hover:bg-sky-600 text-white rounded text-xs transition-colors"
+                    aria-label={`Add ${type} block`}
+                  >
+                    <Plus size={14} />
+                    {type === 'heading1'
+                      ? 'H1'
+                      : type === 'heading2'
+                        ? 'H2'
+                        : type === 'heading3'
+                          ? 'H3'
+                          : type === 'heading4'
+                            ? 'H4'
+                            : type === 'text'
+                              ? 'Text'
+                              : type}
+                  </button>
+                )
+              )}
+            </div>
+          </div>
+
+          {/* Draggable Blocks */}
+          {blocks.length > 0 ? (
+            <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={handleDragEnd}>
+              <SortableContext items={blockIds} strategy={verticalListSortingStrategy}>
+                <div className="space-y-3">
+                  {blocks.map((block) => (
+                    <SortableBlockEditor
+                      key={block.id}
+                      block={block}
+                      onUpdate={updateBlock}
+                      onRemove={() => removeBlock(block.id)}
+                    />
+                  ))}
+                </div>
+              </SortableContext>
+            </DndContext>
+          ) : (
+            <div className="bg-slate-700 rounded-lg p-4 text-center text-slate-400">
+              Add blocks to get started →
+            </div>
+          )}
+
+          {/* Markdown Output */}
+          <div className="bg-slate-800 rounded-lg p-4">
+            <p className="text-sm text-slate-300 mb-2">Generated Markdown:</p>
+            <pre className="bg-slate-900 p-3 rounded text-xs text-amber-100 overflow-x-auto max-h-40 font-mono">
+              {markdown || '(empty)'}
+            </pre>
+          </div>
+        </div>
+
+        {/* Preview */}
+        {showPreview && previewData && (
+          <div className="space-y-3">
+            <h2 className="text-lg font-semibold text-amber-400">Preview</h2>
+            <div className="bg-white dark:bg-slate-900 rounded-lg p-4 prose prose-sm dark:prose-invert max-w-none overflow-y-auto max-h-96 border border-slate-600">
+              <ReactMarkdown>{markdown}</ReactMarkdown>
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/portal/src/pages/sase/BlockRoutingConfig.test.tsx
+++ b/portal/src/pages/sase/BlockRoutingConfig.test.tsx
@@ -149,7 +149,7 @@ describe('BlockRoutingConfig', () => {
     fireEvent.click(addButton);
 
     await waitFor(() => {
-      expect(screen.getByText('Add Route')).toBeInTheDocument();
+      expect(screen.getByRole('heading', { name: /add route/i })).toBeInTheDocument();
       expect(screen.getByPlaceholderText('e.g., web-category:gambling')).toBeInTheDocument();
     });
   });
@@ -175,7 +175,7 @@ describe('BlockRoutingConfig', () => {
     fireEvent.click(screen.getByLabelText('Add new route'));
 
     await waitFor(() => {
-      expect(screen.getByText('Add Route')).toBeInTheDocument();
+      expect(screen.getByRole('heading', { name: /add route/i })).toBeInTheDocument();
     });
 
     // Fill in source type
@@ -184,7 +184,7 @@ describe('BlockRoutingConfig', () => {
     fireEvent.change(sourceInputs[0]!, { target: { value: 'custom-rule:phishing' } });
 
     // Page is already selected by default
-    const saveButton = screen.getByText('Save');
+    const saveButton = screen.getByRole('button', { name: /save/i });
     fireEvent.click(saveButton);
 
     await waitFor(() => {
@@ -199,7 +199,7 @@ describe('BlockRoutingConfig', () => {
     fireEvent.click(screen.getByLabelText('Add new route'));
 
     await waitFor(() => {
-      expect(screen.getByText('Add Route')).toBeInTheDocument();
+      expect(screen.getByRole('heading', { name: /add route/i })).toBeInTheDocument();
     });
 
     // Fill in source type
@@ -221,7 +221,7 @@ describe('BlockRoutingConfig', () => {
     fireEvent.change(urlInputs[0]!, { target: { value: 'https://external-block.example.com' } });
 
     // Save
-    const saveButton = screen.getByText('Save');
+    const saveButton = screen.getByRole('button', { name: /save/i });
     fireEvent.click(saveButton);
 
     await waitFor(() => {
@@ -236,7 +236,7 @@ describe('BlockRoutingConfig', () => {
     fireEvent.click(screen.getByLabelText('Add new route'));
 
     await waitFor(() => {
-      expect(screen.getByText('Add Route')).toBeInTheDocument();
+      expect(screen.getByRole('heading', { name: /add route/i })).toBeInTheDocument();
     });
 
     // Fill in source type
@@ -262,7 +262,7 @@ describe('BlockRoutingConfig', () => {
     fireEvent.change(riskSelect[0]!, { target: { value: 'high' } });
 
     // Save
-    const saveButton = screen.getByText('Save');
+    const saveButton = screen.getByRole('button', { name: /save/i });
     fireEvent.click(saveButton);
 
     await waitFor(() => {
@@ -283,11 +283,11 @@ describe('BlockRoutingConfig', () => {
     fireEvent.click(screen.getByLabelText('Add new route'));
 
     await waitFor(() => {
-      expect(screen.getByText('Add Route')).toBeInTheDocument();
+      expect(screen.getByRole('heading', { name: /add route/i })).toBeInTheDocument();
     });
 
     // Try to save without source type
-    const saveButton = screen.getByText('Save');
+    const saveButton = screen.getByRole('button', { name: /save/i });
     fireEvent.click(saveButton);
 
     await waitFor(() => {

--- a/portal/src/pages/sase/BlockRoutingConfig.test.tsx
+++ b/portal/src/pages/sase/BlockRoutingConfig.test.tsx
@@ -1,0 +1,357 @@
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { BlockRoutingConfig } from './BlockRoutingConfig';
+import * as saseApi from '../../api/sase';
+
+// Mock the API
+jest.mock('../../api/sase');
+const mockedSaseApi = saseApi as jest.Mocked<typeof saseApi>;
+
+describe('BlockRoutingConfig', () => {
+  let queryClient: QueryClient;
+
+  const mockPages: saseApi.BlockPage[] = [
+    {
+      id: 'page-1',
+      tenant: 'tenant-1',
+      name: 'Malware Block Page',
+      markdown: '# Malware Detected',
+      status: 'live',
+      version: 1,
+      created_by: 'user-1',
+      updated_by: null,
+      created_at: new Date().toISOString(),
+      updated_at: new Date().toISOString(),
+    },
+    {
+      id: 'page-2',
+      tenant: 'tenant-1',
+      name: 'Gambling Block Page',
+      markdown: '# Gambling Blocked',
+      status: 'live',
+      version: 1,
+      created_by: 'user-1',
+      updated_by: null,
+      created_at: new Date().toISOString(),
+      updated_at: new Date().toISOString(),
+    },
+  ];
+
+  const mockRoutes: saseApi.BlockRoute[] = [
+    {
+      id: 'route-1',
+      tenant: 'tenant-1',
+      source_type: 'web-category:malware',
+      destination_kind: 'page',
+      page_id: 'page-1',
+      external_url: null,
+      created_at: new Date().toISOString(),
+      created_by: 'user-1',
+      updated_by: null,
+      ticket: null,
+      notes: null,
+      expiry: null,
+      review_date: null,
+      scope: null,
+      risk: null,
+    },
+    {
+      id: 'route-2',
+      tenant: 'tenant-1',
+      source_type: 'web-category:gambling',
+      destination_kind: 'external',
+      page_id: null,
+      external_url: 'https://blocked.example.com',
+      created_at: new Date().toISOString(),
+      created_by: 'user-1',
+      updated_by: null,
+      ticket: 'TICKET-123',
+      notes: 'Redirect to external block page',
+      expiry: null,
+      review_date: null,
+      scope: 'tenant',
+      risk: 'low',
+    },
+  ];
+
+  beforeEach(() => {
+    queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+
+    mockedSaseApi.listBlockPages.mockResolvedValue(mockPages);
+    mockedSaseApi.listBlockRoutes.mockResolvedValue(mockRoutes);
+    mockedSaseApi.upsertBlockRoutes.mockResolvedValue(mockRoutes);
+  });
+
+  const renderComponent = () => {
+    return render(
+      <QueryClientProvider client={queryClient}>
+        <BlockRoutingConfig />
+      </QueryClientProvider>
+    );
+  };
+
+  it('renders the config page with title', async () => {
+    renderComponent();
+
+    await waitFor(() => {
+      expect(screen.getByText('Block Routing Config')).toBeInTheDocument();
+    });
+  });
+
+  it('displays routes table with all columns', async () => {
+    renderComponent();
+
+    await waitFor(() => {
+      expect(screen.getByText('Source Type')).toBeInTheDocument();
+      expect(screen.getByText('Destination')).toBeInTheDocument();
+      expect(screen.getByText('Kind')).toBeInTheDocument();
+      expect(screen.getByText('Actions')).toBeInTheDocument();
+    });
+  });
+
+  it('displays route rows in table', async () => {
+    renderComponent();
+
+    await waitFor(() => {
+      expect(screen.getByText('web-category:malware')).toBeInTheDocument();
+      expect(screen.getByText('web-category:gambling')).toBeInTheDocument();
+      expect(screen.getByText('Malware Block Page')).toBeInTheDocument();
+      expect(screen.getByText('https://blocked.example.com')).toBeInTheDocument();
+    });
+  });
+
+  it('shows page destination kind badge', async () => {
+    renderComponent();
+
+    await waitFor(() => {
+      const badges = screen.getAllByText('page');
+      expect(badges.length).toBeGreaterThan(0);
+    });
+  });
+
+  it('shows external destination kind badge', async () => {
+    renderComponent();
+
+    await waitFor(() => {
+      const badges = screen.getAllByText('external');
+      expect(badges.length).toBeGreaterThan(0);
+    });
+  });
+
+  it('opens modal when Add Route button clicked', async () => {
+    renderComponent();
+
+    const addButton = screen.getByLabelText('Add new route');
+    expect(addButton).toBeInTheDocument();
+    fireEvent.click(addButton);
+
+    await waitFor(() => {
+      expect(screen.getByText('Add Route')).toBeInTheDocument();
+      expect(screen.getByPlaceholderText('e.g., web-category:gambling')).toBeInTheDocument();
+    });
+  });
+
+  it('opens edit modal when edit button clicked', async () => {
+    renderComponent();
+
+    await waitFor(() => {
+      const editButtons = screen.getAllByLabelText(/Edit route/);
+      expect(editButtons.length).toBeGreaterThan(0);
+      fireEvent.click(editButtons[0]!);
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText('Edit Route')).toBeInTheDocument();
+    });
+  });
+
+  it('creates a new page route', async () => {
+    renderComponent();
+
+    // Open add modal
+    fireEvent.click(screen.getByLabelText('Add new route'));
+
+    await waitFor(() => {
+      expect(screen.getByText('Add Route')).toBeInTheDocument();
+    });
+
+    // Fill in source type
+    const sourceInputs = screen.getAllByPlaceholderText('e.g., web-category:gambling');
+    expect(sourceInputs.length).toBeGreaterThan(0);
+    fireEvent.change(sourceInputs[0]!, { target: { value: 'custom-rule:phishing' } });
+
+    // Page is already selected by default
+    const saveButton = screen.getByText('Save');
+    fireEvent.click(saveButton);
+
+    await waitFor(() => {
+      expect(mockedSaseApi.upsertBlockRoutes).toHaveBeenCalled();
+    });
+  });
+
+  it('creates a new external route', async () => {
+    renderComponent();
+
+    // Open add modal
+    fireEvent.click(screen.getByLabelText('Add new route'));
+
+    await waitFor(() => {
+      expect(screen.getByText('Add Route')).toBeInTheDocument();
+    });
+
+    // Fill in source type
+    const sourceInputs = screen.getAllByPlaceholderText('e.g., web-category:gambling');
+    expect(sourceInputs.length).toBeGreaterThan(0);
+    fireEvent.change(sourceInputs[0]!, { target: { value: 'soft-block' } });
+
+    // Switch to external
+    const destSelect = screen.getByDisplayValue('page');
+    fireEvent.change(destSelect, { target: { value: 'external' } });
+
+    await waitFor(() => {
+      expect(screen.getByPlaceholderText('https://example.com/block')).toBeInTheDocument();
+    });
+
+    // Enter external URL
+    const urlInputs = screen.getAllByPlaceholderText('https://example.com/block');
+    expect(urlInputs.length).toBeGreaterThan(0);
+    fireEvent.change(urlInputs[0]!, { target: { value: 'https://external-block.example.com' } });
+
+    // Save
+    const saveButton = screen.getByText('Save');
+    fireEvent.click(saveButton);
+
+    await waitFor(() => {
+      expect(mockedSaseApi.upsertBlockRoutes).toHaveBeenCalled();
+    });
+  });
+
+  it('adds governance metadata', async () => {
+    renderComponent();
+
+    // Open add modal
+    fireEvent.click(screen.getByLabelText('Add new route'));
+
+    await waitFor(() => {
+      expect(screen.getByText('Add Route')).toBeInTheDocument();
+    });
+
+    // Fill in source type
+    const sourceInputs = screen.getAllByPlaceholderText('e.g., web-category:gambling');
+    expect(sourceInputs.length).toBeGreaterThan(0);
+    fireEvent.change(sourceInputs[0]!, { target: { value: 'web-category:violence' } });
+
+    // Fill in metadata
+    const ticketInputs = screen.getAllByPlaceholderText('Ticket ID');
+    expect(ticketInputs.length).toBeGreaterThan(0);
+    fireEvent.change(ticketInputs[0]!, { target: { value: 'SEC-456' } });
+
+    const noteInputs = screen.getAllByPlaceholderText('Notes');
+    expect(noteInputs.length).toBeGreaterThan(0);
+    fireEvent.change(noteInputs[0]!, { target: { value: 'Violence content blocking' } });
+
+    const scopeSelect = screen.getAllByDisplayValue('-- Scope --');
+    expect(scopeSelect.length).toBeGreaterThan(0);
+    fireEvent.change(scopeSelect[0]!, { target: { value: 'tenant' } });
+
+    const riskSelect = screen.getAllByDisplayValue('-- Risk --');
+    expect(riskSelect.length).toBeGreaterThan(0);
+    fireEvent.change(riskSelect[0]!, { target: { value: 'high' } });
+
+    // Save
+    const saveButton = screen.getByText('Save');
+    fireEvent.click(saveButton);
+
+    await waitFor(() => {
+      expect(mockedSaseApi.upsertBlockRoutes).toHaveBeenCalled();
+      const calls = mockedSaseApi.upsertBlockRoutes.mock.calls;
+      expect(calls.length).toBeGreaterThan(0);
+      const callArgs = calls[0]![0]!;
+      expect(callArgs[0]!.metadata?.ticket).toBe('SEC-456');
+      expect(callArgs[0]!.metadata?.notes).toBe('Violence content blocking');
+      expect(callArgs[0]!.metadata?.scope).toBe('tenant');
+      expect(callArgs[0]!.metadata?.risk).toBe('high');
+    });
+  });
+
+  it('validates required fields before saving', async () => {
+    renderComponent();
+
+    fireEvent.click(screen.getByLabelText('Add new route'));
+
+    await waitFor(() => {
+      expect(screen.getByText('Add Route')).toBeInTheDocument();
+    });
+
+    // Try to save without source type
+    const saveButton = screen.getByText('Save');
+    fireEvent.click(saveButton);
+
+    await waitFor(() => {
+      expect(screen.getByText('Source type is required')).toBeInTheDocument();
+    });
+  });
+
+  it('deletes a route', async () => {
+    renderComponent();
+
+    await waitFor(() => {
+      const deleteButtons = screen.getAllByLabelText(/Delete route/);
+      expect(deleteButtons.length).toBeGreaterThan(0);
+    });
+
+    // Mock confirm
+    window.confirm = jest.fn(() => true);
+
+    const deleteButtons = screen.getAllByLabelText(/Delete route/);
+    expect(deleteButtons.length).toBeGreaterThan(0);
+    fireEvent.click(deleteButtons[0]!);
+
+    await waitFor(() => {
+      expect(mockedSaseApi.upsertBlockRoutes).toHaveBeenCalled();
+    });
+  });
+
+  it('shows empty state when no routes', async () => {
+    mockedSaseApi.listBlockRoutes.mockResolvedValue([]);
+
+    renderComponent();
+
+    await waitFor(() => {
+      expect(screen.getByText('No routes configured. Add one to get started.')).toBeInTheDocument();
+    });
+  });
+
+  it('console logs route operations', async () => {
+    const consoleSpy = jest.spyOn(console, 'log').mockImplementation();
+
+    renderComponent();
+
+    await waitFor(() => {
+      expect(consoleSpy).toHaveBeenCalledWith(
+        expect.stringContaining('[BlockRoutingConfig]'),
+        expect.any(Object)
+      );
+    });
+
+    consoleSpy.mockRestore();
+  });
+
+  it('displays route metadata in edit modal', async () => {
+    renderComponent();
+
+    await waitFor(() => {
+      const editButtons = screen.getAllByLabelText(/Edit route/);
+      expect(editButtons.length).toBeGreaterThan(1);
+      fireEvent.click(editButtons[1]!); // Edit the gambling route with metadata
+    });
+
+    await waitFor(() => {
+      expect(screen.getByDisplayValue('TICKET-123')).toBeInTheDocument();
+      expect(screen.getByDisplayValue('Redirect to external block page')).toBeInTheDocument();
+    });
+  });
+});

--- a/portal/src/pages/sase/BlockRoutingConfig.test.tsx
+++ b/portal/src/pages/sase/BlockRoutingConfig.test.tsx
@@ -80,6 +80,9 @@ describe('BlockRoutingConfig', () => {
       defaultOptions: { queries: { retry: false } },
     });
 
+    // Clear all mocks from previous tests
+    jest.clearAllMocks();
+
     mockedSaseApi.listBlockPages.mockResolvedValue(mockPages);
     mockedSaseApi.listBlockRoutes.mockResolvedValue(mockRoutes);
     mockedSaseApi.upsertBlockRoutes.mockResolvedValue(mockRoutes);
@@ -183,12 +186,21 @@ describe('BlockRoutingConfig', () => {
     expect(sourceInputs.length).toBeGreaterThan(0);
     fireEvent.change(sourceInputs[0]!, { target: { value: 'custom-rule:phishing' } });
 
-    // Page is already selected by default
+    // Select a page
+    const pageSelects = screen.getAllByDisplayValue('-- Select a page --');
+    expect(pageSelects.length).toBeGreaterThan(0);
+    fireEvent.change(pageSelects[0]!, { target: { value: 'page-1' } });
+
+    // Save
     const saveButton = screen.getByRole('button', { name: /save/i });
     fireEvent.click(saveButton);
 
     await waitFor(() => {
       expect(mockedSaseApi.upsertBlockRoutes).toHaveBeenCalled();
+      const calls = mockedSaseApi.upsertBlockRoutes.mock.calls;
+      expect(calls.length).toBeGreaterThan(0);
+      const callArgs = calls[0]![0]!;
+      expect(callArgs.some((r) => r.source_type === 'custom-rule:phishing' && r.destination_kind === 'page')).toBe(true);
     });
   });
 
@@ -208,8 +220,9 @@ describe('BlockRoutingConfig', () => {
     fireEvent.change(sourceInputs[0]!, { target: { value: 'soft-block' } });
 
     // Switch to external
-    const destSelect = screen.getByDisplayValue('page');
-    fireEvent.change(destSelect, { target: { value: 'external' } });
+    const destSelects = screen.getAllByDisplayValue('Page');
+    expect(destSelects.length).toBeGreaterThan(0);
+    fireEvent.change(destSelects[0]!, { target: { value: 'external' } });
 
     await waitFor(() => {
       expect(screen.getByPlaceholderText('https://example.com/block')).toBeInTheDocument();
@@ -226,6 +239,10 @@ describe('BlockRoutingConfig', () => {
 
     await waitFor(() => {
       expect(mockedSaseApi.upsertBlockRoutes).toHaveBeenCalled();
+      const calls = mockedSaseApi.upsertBlockRoutes.mock.calls;
+      expect(calls.length).toBeGreaterThan(0);
+      const callArgs = calls[0]![0]!;
+      expect(callArgs.some((r) => r.source_type === 'soft-block' && r.destination_kind === 'external')).toBe(true);
     });
   });
 
@@ -243,6 +260,11 @@ describe('BlockRoutingConfig', () => {
     const sourceInputs = screen.getAllByPlaceholderText('e.g., web-category:gambling');
     expect(sourceInputs.length).toBeGreaterThan(0);
     fireEvent.change(sourceInputs[0]!, { target: { value: 'web-category:violence' } });
+
+    // Select a page for the route to be valid
+    const pageSelects = screen.getAllByDisplayValue('-- Select a page --');
+    expect(pageSelects.length).toBeGreaterThan(0);
+    fireEvent.change(pageSelects[0]!, { target: { value: 'page-1' } });
 
     // Fill in metadata
     const ticketInputs = screen.getAllByPlaceholderText('Ticket ID');
@@ -270,14 +292,17 @@ describe('BlockRoutingConfig', () => {
       const calls = mockedSaseApi.upsertBlockRoutes.mock.calls;
       expect(calls.length).toBeGreaterThan(0);
       const callArgs = calls[0]![0]!;
-      expect(callArgs[0]!.metadata?.ticket).toBe('SEC-456');
-      expect(callArgs[0]!.metadata?.notes).toBe('Violence content blocking');
-      expect(callArgs[0]!.metadata?.scope).toBe('tenant');
-      expect(callArgs[0]!.metadata?.risk).toBe('high');
+      const newRoute = callArgs.find((r) => r.source_type === 'web-category:violence');
+      expect(newRoute?.metadata?.ticket).toBe('SEC-456');
+      expect(newRoute?.metadata?.notes).toBe('Violence content blocking');
+      expect(newRoute?.metadata?.scope).toBe('tenant');
+      expect(newRoute?.metadata?.risk).toBe('high');
     });
   });
 
   it('validates required fields before saving', async () => {
+    const alertSpy = jest.spyOn(window, 'alert').mockImplementation();
+
     renderComponent();
 
     fireEvent.click(screen.getByLabelText('Add new route'));
@@ -291,8 +316,10 @@ describe('BlockRoutingConfig', () => {
     fireEvent.click(saveButton);
 
     await waitFor(() => {
-      expect(screen.getByText('Source type is required')).toBeInTheDocument();
+      expect(alertSpy).toHaveBeenCalledWith('Source type is required');
     });
+
+    alertSpy.mockRestore();
   });
 
   it('deletes a route', async () => {

--- a/portal/src/pages/sase/BlockRoutingConfig.tsx
+++ b/portal/src/pages/sase/BlockRoutingConfig.tsx
@@ -1,0 +1,489 @@
+import React, { useState } from 'react';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { Trash2, Plus, Edit2 } from 'lucide-react';
+import {
+  listBlockPages,
+  listBlockRoutes,
+  upsertBlockRoutes,
+  type BlockRoute,
+  type BlockRouteMetadata,
+} from '../../api/sase';
+
+/**
+ * BlockRoutingConfig — source_type → destination routing table
+ *
+ * Displays a table mapping block sources (source_type) to destinations
+ * (internal pages or external URLs) with governance metadata fields.
+ * Supports CRUD operations for route management.
+ */
+export function BlockRoutingConfig() {
+  const [editingRoute, setEditingRoute] = useState<BlockRoute | null>(null);
+  const [isModalOpen, setIsModalOpen] = useState(false);
+  const [newRoute, setNewRoute] = useState({
+    source_type: '',
+    destination_kind: 'page' as 'page' | 'external',
+    page_id: '',
+    external_url: '',
+    ticket: '',
+    notes: '',
+    expiry: '',
+    review_date: '',
+    scope: '',
+    risk: '',
+  });
+
+  const queryClient = useQueryClient();
+
+  console.log('[BlockRoutingConfig] Render { routes }', { routes: '[querying...]' });
+
+  // Load pages and routes
+  const { data: pages = [] } = useQuery({
+    queryKey: ['blockpages', 'pages'],
+    queryFn: listBlockPages,
+  });
+
+  const { data: routes = [] } = useQuery({
+    queryKey: ['blockpages', 'routes'],
+    queryFn: listBlockRoutes,
+  });
+
+  // Upsert routes mutation
+  const { mutate: saveRoutes, isPending } = useMutation({
+    mutationFn: upsertBlockRoutes,
+    onSuccess: () => {
+      console.log('[BlockRoutingConfig] SaveRoutes success');
+      queryClient.invalidateQueries({ queryKey: ['blockpages', 'routes'] });
+      setIsModalOpen(false);
+      setEditingRoute(null);
+      setNewRoute({
+        source_type: '',
+        destination_kind: 'page',
+        page_id: '',
+        external_url: '',
+        ticket: '',
+        notes: '',
+        expiry: '',
+        review_date: '',
+        scope: '',
+        risk: '',
+      });
+    },
+    onError: (error) => {
+      console.error('[BlockRoutingConfig] SaveRoutes error', { error: String(error) });
+      alert('Failed to save routes');
+    },
+  });
+
+  // Open modal for new route
+  const handleAddRoute = () => {
+    setEditingRoute(null);
+    setNewRoute({
+      source_type: '',
+      destination_kind: 'page',
+      page_id: '',
+      external_url: '',
+      ticket: '',
+      notes: '',
+      expiry: '',
+      review_date: '',
+      scope: '',
+      risk: '',
+    });
+    setIsModalOpen(true);
+  };
+
+  // Open modal for editing route
+  const handleEditRoute = (route: BlockRoute) => {
+    console.log('[BlockRoutingConfig] EditRoute { sourceType }', { sourceType: route.source_type });
+    setEditingRoute(route);
+    setNewRoute({
+      source_type: route.source_type,
+      destination_kind: route.destination_kind,
+      page_id: route.page_id || '',
+      external_url: route.external_url || '',
+      ticket: route.ticket || '',
+      notes: route.notes || '',
+      expiry: route.expiry || '',
+      review_date: route.review_date || '',
+      scope: route.scope || '',
+      risk: route.risk || '',
+    });
+    setIsModalOpen(true);
+  };
+
+  // Save route
+  const handleSaveRoute = () => {
+    if (!newRoute.source_type.trim()) {
+      alert('Source type is required');
+      return;
+    }
+
+    if (newRoute.destination_kind === 'page' && !newRoute.page_id) {
+      alert('Page selection is required');
+      return;
+    }
+
+    if (newRoute.destination_kind === 'external' && !newRoute.external_url.trim()) {
+      alert('External URL is required');
+      return;
+    }
+
+    // Build metadata object with only non-empty values
+    const metadata: BlockRouteMetadata = {};
+    if (newRoute.ticket) metadata.ticket = newRoute.ticket;
+    if (newRoute.notes) metadata.notes = newRoute.notes;
+    if (newRoute.expiry) metadata.expiry = newRoute.expiry;
+    if (newRoute.review_date) metadata.review_date = newRoute.review_date;
+    if (newRoute.scope) metadata.scope = newRoute.scope;
+    if (newRoute.risk) metadata.risk = newRoute.risk;
+
+    // Build route object
+    const routeData = {
+      source_type: newRoute.source_type,
+      destination_kind: newRoute.destination_kind,
+      page_id: newRoute.destination_kind === 'page' ? newRoute.page_id : (undefined as string | undefined),
+      external_url: newRoute.destination_kind === 'external' ? newRoute.external_url : (undefined as string | undefined),
+      metadata: Object.keys(metadata).length > 0 ? metadata : (undefined as BlockRouteMetadata | undefined),
+    };
+
+    // Create the updated routes list
+    const routesToSave = editingRoute
+      ? routes
+          .filter((r) => r.source_type !== editingRoute.source_type)
+          .concat([
+            {
+              ...editingRoute,
+              ...routeData,
+            },
+          ])
+      : routes.concat([routeData as BlockRoute]);
+
+    // Convert to upsert format
+    const routesToUpsert = routesToSave
+      .map((r) => ({
+        source_type: r.source_type,
+        destination_kind: r.destination_kind,
+        page_id: r.page_id,
+        external_url: r.external_url,
+        metadata: {
+          ticket: r.ticket,
+          notes: r.notes,
+          expiry: r.expiry,
+          review_date: r.review_date,
+          scope: r.scope,
+          risk: r.risk,
+        } as BlockRouteMetadata | undefined,
+      }))
+      .filter((r) => {
+        // Remove empty metadata
+        if (r.metadata) {
+          const hasMetadata = Object.values(r.metadata).some((v) => v !== undefined && v !== null && v !== '');
+          if (!hasMetadata) {
+            r.metadata = undefined;
+          }
+        }
+        return true;
+      });
+
+    console.log('[BlockRoutingConfig] SaveRoute { sourceType }', { sourceType: newRoute.source_type });
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    saveRoutes(routesToUpsert as any);
+  };
+
+  // Delete route
+  const handleDeleteRoute = (sourceType: string) => {
+    if (confirm(`Delete route for "${sourceType}"?`)) {
+      const routesToSave = routes.filter((r) => r.source_type !== sourceType);
+      console.log('[BlockRoutingConfig] DeleteRoute { sourceType }', { sourceType });
+
+      const routesToUpsert = routesToSave
+        .map((r) => ({
+          source_type: r.source_type,
+          destination_kind: r.destination_kind,
+          page_id: r.page_id,
+          external_url: r.external_url,
+          metadata: {
+            ticket: r.ticket,
+            notes: r.notes,
+            expiry: r.expiry,
+            review_date: r.review_date,
+            scope: r.scope,
+            risk: r.risk,
+          } as BlockRouteMetadata | undefined,
+        }))
+        .filter((r) => {
+          // Remove empty metadata
+          if (r.metadata) {
+            const hasMetadata = Object.values(r.metadata).some((v) => v !== undefined && v !== null && v !== '');
+            if (!hasMetadata) {
+              r.metadata = undefined;
+            }
+          }
+          return true;
+        });
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      saveRoutes(routesToUpsert as any);
+    }
+  };
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center justify-between">
+        <h1 className="text-2xl font-bold text-amber-400">Block Routing Config</h1>
+        <button
+          onClick={handleAddRoute}
+          className="flex items-center gap-2 px-3 py-2 bg-sky-600 hover:bg-sky-700 text-white rounded transition-colors"
+          aria-label="Add new route"
+        >
+          <Plus size={16} />
+          Add Route
+        </button>
+      </div>
+
+      {/* Routes Table */}
+      {routes.length > 0 ? (
+        <div className="bg-slate-800 rounded-lg overflow-hidden">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="bg-slate-700 border-b border-slate-600">
+                <th className="px-4 py-3 text-left text-amber-400 font-semibold">Source Type</th>
+                <th className="px-4 py-3 text-left text-amber-400 font-semibold">Destination</th>
+                <th className="px-4 py-3 text-left text-amber-400 font-semibold">Kind</th>
+                <th className="px-4 py-3 text-left text-amber-400 font-semibold">Actions</th>
+              </tr>
+            </thead>
+            <tbody>
+              {routes.map((route, idx) => (
+                <tr
+                  key={route.id}
+                  className={`border-b border-slate-600 ${idx % 2 === 0 ? 'bg-slate-800' : 'bg-slate-750'}`}
+                >
+                  <td className="px-4 py-3 text-slate-100 font-mono text-xs">{route.source_type}</td>
+                  <td className="px-4 py-3 text-slate-300">
+                    {route.destination_kind === 'page'
+                      ? pages.find((p) => p.id === route.page_id)?.name || route.page_id
+                      : route.external_url}
+                  </td>
+                  <td className="px-4 py-3">
+                    <span
+                      className={`px-2 py-1 rounded text-xs font-medium ${
+                        route.destination_kind === 'page'
+                          ? 'bg-blue-900 text-blue-100'
+                          : 'bg-green-900 text-green-100'
+                      }`}
+                    >
+                      {route.destination_kind}
+                    </span>
+                  </td>
+                  <td className="px-4 py-3 flex gap-2">
+                    <button
+                      onClick={() => handleEditRoute(route)}
+                      className="text-amber-400 hover:text-amber-300 transition-colors"
+                      aria-label={`Edit route for ${route.source_type}`}
+                    >
+                      <Edit2 size={16} />
+                    </button>
+                    <button
+                      onClick={() => handleDeleteRoute(route.source_type)}
+                      className="text-red-400 hover:text-red-300 transition-colors"
+                      aria-label={`Delete route for ${route.source_type}`}
+                    >
+                      <Trash2 size={16} />
+                    </button>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      ) : (
+        <div className="bg-slate-800 rounded-lg p-8 text-center text-slate-400">
+          No routes configured. Add one to get started.
+        </div>
+      )}
+
+      {/* Modal */}
+      {isModalOpen && (
+        <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 p-4">
+          <div className="bg-slate-800 rounded-lg p-6 max-w-md w-full space-y-4">
+            <h2 className="text-lg font-bold text-amber-400">
+              {editingRoute ? 'Edit Route' : 'Add Route'}
+            </h2>
+
+            {/* Source Type */}
+            <div>
+              <label className="block text-sm text-slate-300 mb-1">Source Type</label>
+              <input
+                type="text"
+                value={newRoute.source_type}
+                onChange={(e) =>
+                  setNewRoute({
+                    ...newRoute,
+                    source_type: e.target.value,
+                  })
+                }
+                placeholder="e.g., web-category:gambling"
+                disabled={!!editingRoute}
+                className="w-full bg-slate-700 text-white px-3 py-2 rounded border border-slate-600 focus:border-amber-400 focus:outline-none disabled:opacity-50"
+              />
+            </div>
+
+            {/* Destination Kind */}
+            <div>
+              <label className="block text-sm text-slate-300 mb-1">Destination Type</label>
+              <select
+                value={newRoute.destination_kind}
+                onChange={(e) =>
+                  setNewRoute({
+                    ...newRoute,
+                    destination_kind: e.target.value as 'page' | 'external',
+                  })
+                }
+                className="w-full bg-slate-700 text-white px-3 py-2 rounded border border-slate-600 focus:border-amber-400 focus:outline-none"
+              >
+                <option value="page">Page</option>
+                <option value="external">External URL</option>
+              </select>
+            </div>
+
+            {/* Page Selection or External URL */}
+            {newRoute.destination_kind === 'page' ? (
+              <div>
+                <label className="block text-sm text-slate-300 mb-1">Select Page</label>
+                <select
+                  value={newRoute.page_id}
+                  onChange={(e) =>
+                    setNewRoute({
+                      ...newRoute,
+                      page_id: e.target.value,
+                    })
+                  }
+                  className="w-full bg-slate-700 text-white px-3 py-2 rounded border border-slate-600 focus:border-amber-400 focus:outline-none"
+                >
+                  <option value="">-- Select a page --</option>
+                  {pages.map((page) => (
+                    <option key={page.id} value={page.id}>
+                      {page.name}
+                    </option>
+                  ))}
+                </select>
+              </div>
+            ) : (
+              <div>
+                <label className="block text-sm text-slate-300 mb-1">External URL</label>
+                <input
+                  type="url"
+                  value={newRoute.external_url}
+                  onChange={(e) =>
+                    setNewRoute({
+                      ...newRoute,
+                      external_url: e.target.value,
+                    })
+                  }
+                  placeholder="https://example.com/block"
+                  className="w-full bg-slate-700 text-white px-3 py-2 rounded border border-slate-600 focus:border-amber-400 focus:outline-none"
+                />
+              </div>
+            )}
+
+            {/* Governance Metadata */}
+            <div className="border-t border-slate-600 pt-4">
+              <p className="text-sm text-slate-300 font-semibold mb-3">Governance Metadata (Optional)</p>
+
+              <div className="space-y-3">
+                <input
+                  type="text"
+                  value={newRoute.ticket}
+                  onChange={(e) =>
+                    setNewRoute({
+                      ...newRoute,
+                      ticket: e.target.value,
+                    })
+                  }
+                  placeholder="Ticket ID"
+                  className="w-full bg-slate-700 text-white px-3 py-2 rounded border border-slate-600 focus:border-amber-400 focus:outline-none text-sm"
+                />
+
+                <textarea
+                  value={newRoute.notes}
+                  onChange={(e) =>
+                    setNewRoute({
+                      ...newRoute,
+                      notes: e.target.value,
+                    })
+                  }
+                  placeholder="Notes"
+                  rows={2}
+                  className="w-full bg-slate-700 text-white px-3 py-2 rounded border border-slate-600 focus:border-amber-400 focus:outline-none text-sm"
+                />
+
+                <input
+                  type="date"
+                  value={newRoute.expiry}
+                  onChange={(e) =>
+                    setNewRoute({
+                      ...newRoute,
+                      expiry: e.target.value,
+                    })
+                  }
+                  className="w-full bg-slate-700 text-white px-3 py-2 rounded border border-slate-600 focus:border-amber-400 focus:outline-none text-sm"
+                />
+
+                <select
+                  value={newRoute.scope}
+                  onChange={(e) =>
+                    setNewRoute({
+                      ...newRoute,
+                      scope: e.target.value,
+                    })
+                  }
+                  className="w-full bg-slate-700 text-white px-3 py-2 rounded border border-slate-600 focus:border-amber-400 focus:outline-none text-sm"
+                >
+                  <option value="">-- Scope --</option>
+                  <option value="global">Global</option>
+                  <option value="tenant">Tenant</option>
+                  <option value="team">Team</option>
+                </select>
+
+                <select
+                  value={newRoute.risk}
+                  onChange={(e) =>
+                    setNewRoute({
+                      ...newRoute,
+                      risk: e.target.value,
+                    })
+                  }
+                  className="w-full bg-slate-700 text-white px-3 py-2 rounded border border-slate-600 focus:border-amber-400 focus:outline-none text-sm"
+                >
+                  <option value="">-- Risk --</option>
+                  <option value="low">Low</option>
+                  <option value="medium">Medium</option>
+                  <option value="high">High</option>
+                </select>
+              </div>
+            </div>
+
+            {/* Buttons */}
+            <div className="flex gap-2 pt-4 border-t border-slate-600">
+              <button
+                onClick={handleSaveRoute}
+                disabled={isPending}
+                className="flex-1 px-4 py-2 bg-green-600 hover:bg-green-700 text-white rounded disabled:opacity-50 transition-colors"
+              >
+                {isPending ? 'Saving...' : 'Save'}
+              </button>
+              <button
+                onClick={() => setIsModalOpen(false)}
+                className="flex-1 px-4 py-2 bg-slate-700 hover:bg-slate-600 text-white rounded transition-colors"
+              >
+                Cancel
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/portal/src/pages/sase/BlockRoutingConfig.tsx
+++ b/portal/src/pages/sase/BlockRoutingConfig.tsx
@@ -137,29 +137,13 @@ export function BlockRoutingConfig() {
     if (newRoute.scope) metadata.scope = newRoute.scope;
     if (newRoute.risk) metadata.risk = newRoute.risk;
 
-    // Build route object
-    const routeData = {
-      source_type: newRoute.source_type,
-      destination_kind: newRoute.destination_kind,
-      page_id: newRoute.destination_kind === 'page' ? newRoute.page_id : (undefined as string | undefined),
-      external_url: newRoute.destination_kind === 'external' ? newRoute.external_url : (undefined as string | undefined),
-      metadata: Object.keys(metadata).length > 0 ? metadata : (undefined as BlockRouteMetadata | undefined),
-    };
+    // For editing: filter out the old route; for creating: keep all
+    const existingRoutes = editingRoute
+      ? routes.filter((r) => r.source_type !== editingRoute.source_type)
+      : routes;
 
-    // Create the updated routes list
-    const routesToSave = editingRoute
-      ? routes
-          .filter((r) => r.source_type !== editingRoute.source_type)
-          .concat([
-            {
-              ...editingRoute,
-              ...routeData,
-            },
-          ])
-      : routes.concat([routeData as BlockRoute]);
-
-    // Convert to upsert format
-    const routesToUpsert = routesToSave
+    // Build upsert payload (not trying to be BlockRoute objects - the server returns those)
+    const routesToUpsert = existingRoutes
       .map((r) => ({
         source_type: r.source_type,
         destination_kind: r.destination_kind,
@@ -174,57 +158,67 @@ export function BlockRoutingConfig() {
           risk: r.risk,
         } as BlockRouteMetadata | undefined,
       }))
-      .filter((r) => {
-        // Remove empty metadata
+      .concat([
+        {
+          source_type: newRoute.source_type,
+          destination_kind: newRoute.destination_kind,
+          page_id: newRoute.destination_kind === 'page' ? newRoute.page_id : (null as string | null),
+          external_url: newRoute.destination_kind === 'external' ? newRoute.external_url : (null as string | null),
+          metadata: Object.keys(metadata).length > 0 ? metadata : (undefined as BlockRouteMetadata | undefined),
+        },
+      ]);
+
+    // Remove empty metadata from all routes
+    const finalRoutes = routesToUpsert.map((r) => {
+      if (r.metadata) {
+        const hasMetadata = Object.values(r.metadata).some((v) => v !== undefined && v !== null && v !== '');
+        if (!hasMetadata) {
+          r.metadata = undefined;
+        }
+      }
+      return r;
+    });
+
+    console.log('[BlockRoutingConfig] SaveRoute { sourceType }', { sourceType: newRoute.source_type });
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    saveRoutes(finalRoutes as any);
+  };
+
+  // Delete route
+  const handleDeleteRoute = (sourceType: string) => {
+    if (confirm(`Delete route for "${sourceType}"?`)) {
+      const remainingRoutes = routes.filter((r) => r.source_type !== sourceType);
+      console.log('[BlockRoutingConfig] DeleteRoute { sourceType }', { sourceType });
+
+      const routesToUpsert = remainingRoutes.map((r) => ({
+        source_type: r.source_type,
+        destination_kind: r.destination_kind,
+        page_id: r.page_id,
+        external_url: r.external_url,
+        metadata: {
+          ticket: r.ticket,
+          notes: r.notes,
+          expiry: r.expiry,
+          review_date: r.review_date,
+          scope: r.scope,
+          risk: r.risk,
+        } as BlockRouteMetadata | undefined,
+      }));
+
+      // Remove empty metadata
+      const finalRoutes = routesToUpsert.map((r) => {
         if (r.metadata) {
           const hasMetadata = Object.values(r.metadata).some((v) => v !== undefined && v !== null && v !== '');
           if (!hasMetadata) {
             r.metadata = undefined;
           }
         }
-        return true;
+        return r;
       });
 
-    console.log('[BlockRoutingConfig] SaveRoute { sourceType }', { sourceType: newRoute.source_type });
-
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    saveRoutes(routesToUpsert as any);
-  };
-
-  // Delete route
-  const handleDeleteRoute = (sourceType: string) => {
-    if (confirm(`Delete route for "${sourceType}"?`)) {
-      const routesToSave = routes.filter((r) => r.source_type !== sourceType);
-      console.log('[BlockRoutingConfig] DeleteRoute { sourceType }', { sourceType });
-
-      const routesToUpsert = routesToSave
-        .map((r) => ({
-          source_type: r.source_type,
-          destination_kind: r.destination_kind,
-          page_id: r.page_id,
-          external_url: r.external_url,
-          metadata: {
-            ticket: r.ticket,
-            notes: r.notes,
-            expiry: r.expiry,
-            review_date: r.review_date,
-            scope: r.scope,
-            risk: r.risk,
-          } as BlockRouteMetadata | undefined,
-        }))
-        .filter((r) => {
-          // Remove empty metadata
-          if (r.metadata) {
-            const hasMetadata = Object.values(r.metadata).some((v) => v !== undefined && v !== null && v !== '');
-            if (!hasMetadata) {
-              r.metadata = undefined;
-            }
-          }
-          return true;
-        });
-
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      saveRoutes(routesToUpsert as any);
+      saveRoutes(finalRoutes as any);
     }
   };
 

--- a/portal/src/routes/saseViews.ts
+++ b/portal/src/routes/saseViews.ts
@@ -2,10 +2,14 @@ import type { ComponentType } from 'react';
 import { ClustersPage } from '../pages/sase/ClustersPage';
 import { ClientsPage } from '../pages/sase/ClientsPage';
 import { StatusPage } from '../pages/sase/StatusPage';
+import { BlockPageBuilder } from '../pages/sase/BlockPageBuilder';
+import { BlockRoutingConfig } from '../pages/sase/BlockRoutingConfig';
 
 /** View-slug -> page map for the sase module. Slugs derived from NavEntry labels. */
 export const saseViews: Record<string, ComponentType> = {
   clusters: ClustersPage,
   clients: ClientsPage,
   status: StatusPage,
+  'block-pages': BlockPageBuilder,
+  'block-routing': BlockRoutingConfig,
 };


### PR DESCRIPTION
SASE Slice C portal (Task 6) — the admin UI for block pages, over the merged blockpages backend.

- **BlockPageBuilder** — drag-drop (dnd-kit) palette of basic markdown elements (H1–H4, image, text, link, list, divider) → serializes to a **markdown** document; live preview (react-markdown), save/publish/version, template-variable helper.
- **BlockRoutingConfig** — source_type → destination (internal page | external URL) table + governance-metadata editor; CRUD via the blockpages API.
- Typed API client (mirrors server DTOs), registered as `/m/sase/block-pages` + `/m/sase/block-routing`, role-based visibility, Tailwind v4 dark theme, a11y, sanitized console logging.
- Deps: @dnd-kit/*, react-markdown (exact-pinned).

Verified: both suites **28/28 pass**, tsc --noEmit 0 errors, eslint clean, Vite build passes.

_Pre-existing (NOT introduced here — unchanged by this branch): App.test.tsx + c2c/RunsPage.test.tsx fail on release too — separate portal-test-debt item. Marketing screenshots: feature is flag-gated OFF (not in the public product set until enabled)._

🤖 Generated with [Claude Code](https://claude.com/claude-code)