### PR TITLE
fix(portal): resolve pre-existing App + RunsPage test failures

### DIFF
--- a/portal/src/components/DataTable.tsx
+++ b/portal/src/components/DataTable.tsx
@@ -153,7 +153,7 @@ export function DataTable<T extends { id?: string }>({
               >
                 {columns.map((col) => (
                   <td
-                    key={String(col.key)}
+                    key={`${row.id || idx}-${String(col.key)}`}
                     className="px-4 py-3 text-slate-200"
                   >
                     {col.render

--- a/portal/src/pages/c2c/RunsPage.test.tsx
+++ b/portal/src/pages/c2c/RunsPage.test.tsx
@@ -119,7 +119,7 @@ describe('RunsPage', () => {
 
     await waitFor(() => {
       expect(
-        screen.getByPlaceholderText('latency, throughput')
+        screen.getByPlaceholderText('http, tcp, udp, icmp')
       ).toBeInTheDocument();
     });
 
@@ -128,7 +128,7 @@ describe('RunsPage', () => {
 
     await waitFor(() => {
       expect(
-        screen.queryByPlaceholderText('latency, throughput')
+        screen.queryByPlaceholderText('http, tcp, udp, icmp')
       ).not.toBeInTheDocument();
     });
   });
@@ -144,7 +144,7 @@ describe('RunsPage', () => {
     const createButton = screen.getByText('Create Run');
     await userEvent.click(createButton);
 
-    const testTypesInput = screen.getByPlaceholderText('latency, throughput');
+    const testTypesInput = screen.getByPlaceholderText('http, tcp, udp, icmp');
     const submitButton = screen.getByRole('button', { name: /Create/ });
 
     await userEvent.clear(testTypesInput);

--- a/portal/src/setupTests.ts
+++ b/portal/src/setupTests.ts
@@ -1,5 +1,11 @@
 import '@testing-library/jest-dom';
 
+// Mock react-markdown to avoid ESM parsing issues in Jest
+jest.mock('react-markdown', () => ({
+  __esModule: true,
+  default: ({ children }: { children: React.ReactNode }) => children,
+}));
+
 // Mock sessionStorage
 const sessionStorageMock: Record<string, string> = {};
 


### PR DESCRIPTION
Portal test debt (pre-existing on release, unrelated to the blockpages work).

- **App.test.tsx**: react-markdown ESM not transformed by Jest → SyntaxError. Fixed with a global react-markdown mock in `setupTests.ts`.
- **RunsPage.test.tsx**: (1) `DataTable` had duplicate React keys on `<td>` (key = column key, not unique per cell) → key now `${row.id||idx}-${col.key}`; (2) stale test placeholders (`latency, throughput` → actual `http, tcp, udp, icmp`).

Verified myself: App(8) + RunsPage(10) + DataTable + ClustersPage + BlockPageBuilder/BlockRoutingConfig(28) all pass (46+28); tsc 0 errors; lint clean. The shared DataTable key fix regresses no consumer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)