### PR TITLE
fix(helm): tobogganing.namespace helper + env-suffix compliance

### DIFF
--- a/k8s/helm/tobogganing/templates/_helpers.tpl
+++ b/k8s/helm/tobogganing/templates/_helpers.tpl
@@ -80,5 +80,5 @@ Create the name of the service account to use
 Namespace helper
 */}}
 {{- define "tobogganing.namespace" -}}
-{{- default .Values.namespace .Release.Namespace }}
+{{- default .Release.Namespace .Values.namespace }}
 {{- end }}

--- a/k8s/helm/tobogganing/values-alpha.yaml
+++ b/k8s/helm/tobogganing/values-alpha.yaml
@@ -1,7 +1,7 @@
 ## Tobogganing - Alpha Environment Overrides
 ## Minimal resources for development/testing
 
-namespace: tobogganing-alpha
+namespace: tobogganing
 
 hubApi:
   replicas: 1

--- a/k8s/helm/tobogganing/values-beta.yaml
+++ b/k8s/helm/tobogganing/values-beta.yaml
@@ -1,7 +1,7 @@
 ## Tobogganing - Beta Environment Overrides
 ## Moderate resources for staging/QA
 
-namespace: tobogganing-beta
+namespace: tobogganing
 
 hubApi:
   replicas: 2

--- a/k8s/helm/tobogganing/values-prod.yaml
+++ b/k8s/helm/tobogganing/values-prod.yaml
@@ -1,7 +1,7 @@
 ## Tobogganing - Production Environment Overrides
 ## Full resources with autoscaling
 
-namespace: tobogganing-prod
+namespace: tobogganing
 
 hubApi:
   replicas: 3


### PR DESCRIPTION
Two related Helm fixes.

1. **Helper bug** (`_helpers.tpl:83`): `default .Values.namespace .Release.Namespace` had args backwards → always returned `.Release.Namespace`, ignoring `.Values.namespace`. Swapped to `default .Release.Namespace .Values.namespace` (values wins, release fallback).
2. **Env-suffix violation the fix exposed** (would have regressed deploys): `values-{alpha,beta,prod}.yaml` set `namespace: tobogganing-{env}` — violates devops-kubernetes.md ('namespace = product name ONLY; env suffix lives on values FILENAMES, nowhere else'). The original helper bug was accidentally suppressing this; the fix un-masked it. Set all env namespaces to `tobogganing`.

Verified: per-env renders (alpha/beta/prod) all → `namespace: tobogganing`; `--set namespace=x` honored; helm lint passes.

_Flagged follow-up (not done — touches CI/deploy-script refs): the `values-{env}.yaml` files should be renamed to the canonical `{env}.yml`._

🤖 Generated with [Claude Code](https://claude.com/claude-code)